### PR TITLE
Fix piped stdin input reader on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,7 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
+ "filedescriptor",
  "mio",
  "parking_lot",
  "rustix",
@@ -361,6 +362,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -919,7 +931,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1140,7 +1152,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1161,7 +1173,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1658,9 +1670,18 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "yaml-rust",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -1669,7 +1690,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ sha2          = "0.10"
 toml          = "0.8"
 unicodeit     = "0.2"
 mmdflux       = "2.1"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+crossterm     = { version = "0.28", features = ["use-dev-tty"] }


### PR DESCRIPTION
Hey, cool project! I ran into a piped-stdin issue on macOS and this small dependency-targeting change seems to address it without changing the working behavior on other platforms.

## Summary

This enables Crossterm's `use-dev-tty` feature only for macOS builds so `leaf` can read Markdown from piped stdin while still receiving keyboard events from the controlling terminal.

In manual cross-platform testing, the failure reproduced on macOS Tahoe 26 but not on Windows 11 or Ubuntu 24.04. After this change, the same piped-stdin flow worked on all three platforms.

## Reproduction

```sh
echo '# Hello' | RUST_BACKTRACE=1 cargo run -q -- --debug-input
```

## Expected

`leaf` renders the piped Markdown and still accepts terminal keyboard input, such as `q` to quit.

## Actual on macOS Tahoe 26

The UI initializes and renders, then exits with:

```text
Error: Failed to initialize input reader
```

The backtrace points at the event read loop:

```text
leaf::runtime::run
  at ./src/runtime.rs:136:19
```

The debug log shows stdin was already read and the initial draw completed before the failure:

```text
main input_ready filename=stdin filepath=<none> picker=false watch=false
terminal enter done
initial_draw draw done
initial_draw sync end done
run loop start
run loop end
```

So this does not look like a Markdown/stdin read failure. The failure happens when Crossterm initializes terminal event input after stdin has already been consumed as document data.

## Platform Results

Manual testing used the piped-stdin command above, then `q` to quit when the UI stayed open.

| Platform | Before this change | After this change |
| --- | --- | --- |
| Windows 11 | Worked | Worked |
| Ubuntu 24.04 | Worked | Worked |
| macOS Tahoe 26 | Failed with `Failed to initialize input reader` | Worked |

## Upstream Context

This appears to be a known Crossterm behavior around apps that consume stdin as data while still needing terminal input from `/dev/tty`:

- https://github.com/crossterm-rs/crossterm/pull/957
- https://github.com/crossterm-rs/crossterm/issues/396
- https://github.com/crossterm-rs/crossterm/issues/728
- https://github.com/crossterm-rs/crossterm/issues/941
- https://github.com/crossterm-rs/crossterm/issues/919
- https://github.com/crossterm-rs/crossterm/issues/996
- https://docs.rs/crossterm/latest/crossterm/

Crossterm's default Unix event reader can hide the underlying initialization error and later report only `Failed to initialize input reader`. The upstream discussion points at `use-dev-tty` as the intended workaround for this kind of piped-stdin TUI case. In this manual test matrix, the default behavior only surfaced as a user-visible failure on macOS.

## Why This Fix

This keeps the default dependency unchanged:

```toml
[dependencies]
crossterm     = "0.28"
```

and enables the workaround only for macOS:

```toml
[target.'cfg(target_os = "macos")'.dependencies]
crossterm     = { version = "0.28", features = ["use-dev-tty"] }
```

Pros:

- Fixes the macOS piped-stdin TUI failure in manual testing.
- Keeps the application code unchanged.
- Preserves the working default Crossterm backend on Windows 11 and Ubuntu 24.04.
- Avoids broadening the workaround to Linux, where the default Mio-backed Unix path worked in testing.
- Matches the upstream Crossterm workaround for separating document stdin from terminal event input on affected macOS terminals.

Tradeoffs:

- On macOS, this opts Crossterm into its `/dev/tty` polling path instead of the default Mio event source.
- The lockfile gains `filedescriptor` and its transitive `thiserror` dependency from the macOS-only feature.
- This is a dependency-level workaround while upstream discusses a cleaner explicit input-source API.

Alternatives considered:

- Enabling `use-dev-tty` for all platforms. That also worked in testing, but changed Linux behavior unnecessarily.
- Waiting for Crossterm PR #957 or a future input-source API. That would be cleaner upstream, but the PR has been open for a while and does not help current `leaf` users on affected macOS terminals.
- Reworking terminal input around another lower-level backend. That would be much larger than this bug seems to require.

## Validation

- Manual piped-stdin smoke test on Windows 11: worked before and after this change.
- Manual piped-stdin smoke test on Ubuntu 24.04: worked before and after this change.
- Manual piped-stdin smoke test on macOS Tahoe 26: failed before this change, worked after this change.
- `cargo tree --target aarch64-apple-darwin -e features -i crossterm` shows `use-dev-tty` enabled for macOS.
- `cargo tree --target x86_64-unknown-linux-gnu -e features -i crossterm` shows `use-dev-tty` is not enabled for Linux.
- `cargo fmt --check`
- `env -u EDITOR -u VISUAL cargo test` (`129 passed`)
- On macOS, `echo '# Hello' | cargo run -q -- --debug-input`, then `q` to quit successfully.

Note: plain `cargo test` in my local shell is currently affected by `EDITOR`/`VISUAL` being set to `/opt/homebrew/bin/nvim`; one existing editor-resolution test expects the config fallback path. Unsetting those env vars makes the suite pass.
