### PR TITLE
feat: add custom theme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ cat TESTING.md | leaf
 
 ## Configuration
 
-Set default values for theme, editor, and watch mode via `config.toml`:
+Set default values for theme, editor, watch mode, and custom themes via `config.toml`:
 
 ```bash
 leaf --config
@@ -139,9 +139,28 @@ leaf --config
 This opens the configuration file in your editor. If the file does not exist yet, leaf creates it with documented defaults.
 
 ```toml
-theme = "ocean"      # arctic, forest, ocean, solarized-dark
+theme = "ocean"      # arctic, forest, ocean, solarized-dark, or a custom theme file
 editor = "nano"      # any editor in PATH
 watch = false        # auto-reload when opening a file
+
+# Optional custom theme file, resolved relative to config.toml:
+# theme = "gruvbox.toml"
+```
+
+Custom theme files can inherit from a built-in base and override only the colors you set:
+
+```toml
+# gruvbox.toml
+base = "ocean"
+syntax = "base16-ocean.dark"
+
+[ui]
+content_bg = "#282828"
+toc_accent = "#fe8019"
+
+[markdown]
+text = "#ebdbb2"
+heading_1 = "#fabd2f"
 ```
 
 All settings are optional. CLI arguments always take priority. See [`config.toml`](config.toml) for details.

--- a/config.toml
+++ b/config.toml
@@ -11,9 +11,17 @@
 # Command-line arguments always take priority over this file.
 
 # Color theme
-# Available: arctic, forest, ocean, solarized-dark
+# Built-in themes: arctic, forest, ocean, solarized-dark
+# Or set this to a custom theme file path, relative to this config file.
 # Default: ocean
 theme = "ocean"
+
+# Custom theme files inherit from a built-in base and override only the colors
+# you set. To use one, set theme to its path:
+#
+# theme = "gruvbox.toml"
+#
+# Relative paths are resolved from this config file's directory.
 
 # Default editor for Ctrl+E
 # Any editor name available in PATH: nano, vim, nvim, micro,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -5,7 +5,7 @@ use crate::{
         toc::{should_hide_single_h1, should_promote_h2_when_no_h1, toc_display_level, TocEntry},
     },
     render::{build_status_bar, build_toc_line_with_index, toc_header_line},
-    theme::{current_syntect_theme, current_theme_preset, theme_preset_index},
+    theme::{current_syntect_theme, current_theme_selection, theme_preset_index},
 };
 use ratatui::{layout::Rect, text::Line};
 use std::{
@@ -235,8 +235,9 @@ impl App {
             picker_load_state: PickerLoadState::Idle,
             theme_picker: ThemePickerState {
                 open: false,
-                index: theme_preset_index(current_theme_preset()),
+                index: theme_preset_index(current_theme_selection().preset_hint()),
                 original: None,
+                original_preview: None,
                 preview_cache: vec![None; crate::theme::THEME_PRESETS.len()],
             },
             editor_picker: EditorPickerState {
@@ -761,7 +762,7 @@ impl App {
         }
 
         self.invalidate_theme_preview_cache();
-        self.store_theme_preview(current_theme_preset(), &new_lines, &new_toc);
+        self.store_current_theme_preview_from(&new_lines, &new_toc);
         self.replace_content(new_lines, new_toc);
         if !self.search.query.is_empty() && !self.search.mode {
             self.run_search();
@@ -801,7 +802,7 @@ impl App {
         self.search.mode = false;
         self.reset_search_state();
         self.invalidate_theme_preview_cache();
-        self.store_theme_preview(current_theme_preset(), &lines, &toc);
+        self.store_current_theme_preview_from(&lines, &toc);
         self.replace_content(lines, toc);
         true
     }

--- a/src/app/theme_picker.rs
+++ b/src/app/theme_picker.rs
@@ -1,8 +1,8 @@
 use crate::{
     markdown::{parse_markdown_with_width, toc::TocEntry},
     theme::{
-        current_syntect_theme, current_theme_preset, set_theme_preset, theme_preset_index,
-        ThemePreset, THEME_PRESETS,
+        current_syntect_theme, current_theme_selection, set_theme_preset, set_theme_selection,
+        theme_preset_index, ThemePreset, ThemeSelection, THEME_PRESETS,
     },
 };
 use ratatui::text::Line;
@@ -19,22 +19,28 @@ pub(crate) struct ThemePreviewCacheEntry {
 pub(crate) struct ThemePickerState {
     pub(super) open: bool,
     pub(super) index: usize,
-    pub(super) original: Option<ThemePreset>,
+    pub(super) original: Option<ThemeSelection>,
+    pub(super) original_preview: Option<ThemePreviewCacheEntry>,
     pub(super) preview_cache: Vec<Option<ThemePreviewCacheEntry>>,
 }
 
 impl App {
     pub(crate) fn open_theme_picker(&mut self) {
         self.theme_picker.open = true;
-        let current = current_theme_preset();
-        self.theme_picker.index = theme_preset_index(current);
+        let current = current_theme_selection();
+        self.theme_picker.index = theme_preset_index(current.preset_hint());
         self.theme_picker.original = Some(current);
+        self.theme_picker.original_preview = Some(ThemePreviewCacheEntry {
+            lines: self.lines.clone(),
+            toc: self.toc.clone(),
+        });
         self.store_current_theme_preview();
     }
 
     pub(crate) fn close_theme_picker(&mut self) {
         self.theme_picker.open = false;
         self.theme_picker.original = None;
+        self.theme_picker.original_preview = None;
     }
 
     pub(crate) fn is_theme_picker_open(&self) -> bool {
@@ -46,12 +52,16 @@ impl App {
     }
 
     #[cfg(test)]
-    pub(crate) fn theme_picker_original(&self) -> Option<ThemePreset> {
-        self.theme_picker.original
+    pub(crate) fn theme_picker_original(&self) -> Option<ThemeSelection> {
+        self.theme_picker.original.clone()
     }
 
-    pub(crate) fn theme_picker_reference_preset(&self) -> ThemePreset {
-        self.theme_picker.original.unwrap_or(current_theme_preset())
+    pub(crate) fn theme_picker_reference_preset(&self) -> Option<ThemePreset> {
+        self.theme_picker
+            .original
+            .as_ref()
+            .and_then(ThemeSelection::as_preset)
+            .or_else(|| current_theme_selection().as_preset())
     }
 
     pub(crate) fn move_theme_picker_up(&mut self) {
@@ -93,7 +103,7 @@ impl App {
         ss: &SyntaxSet,
         themes: &ThemeSet,
     ) {
-        if current_theme_preset() == preset {
+        if current_theme_selection().as_preset() == Some(preset) {
             return;
         }
         set_theme_preset(preset);
@@ -116,8 +126,16 @@ impl App {
     }
 
     pub(crate) fn restore_theme_picker_preview(&mut self, ss: &SyntaxSet, themes: &ThemeSet) {
-        if let Some(original) = self.theme_picker.original {
-            self.preview_theme_preset(original, ss, themes);
+        if let Some(original) = self.theme_picker.original.clone() {
+            set_theme_selection(original);
+            if let Some(entry) = self.theme_picker.original_preview.clone() {
+                self.replace_content(entry.lines, entry.toc);
+            } else {
+                let theme = current_syntect_theme(themes);
+                let (new_lines, new_toc) =
+                    parse_markdown_with_width(&self.source, ss, theme, self.render_width);
+                self.replace_content(new_lines, new_toc);
+            }
         }
         self.close_theme_picker();
     }
@@ -138,7 +156,9 @@ impl App {
     }
 
     pub(crate) fn store_current_theme_preview(&mut self) {
-        let preset = current_theme_preset();
+        let Some(preset) = current_theme_selection().as_preset() else {
+            return;
+        };
         let idx = theme_preset_index(preset);
         if let Some(slot) = self.theme_picker.preview_cache.get_mut(idx) {
             *slot = Some(ThemePreviewCacheEntry {
@@ -146,6 +166,17 @@ impl App {
                 toc: self.toc.clone(),
             });
         }
+    }
+
+    pub(crate) fn store_current_theme_preview_from(
+        &mut self,
+        lines: &[Line<'static>],
+        toc: &[TocEntry],
+    ) {
+        let Some(preset) = current_theme_selection().as_preset() else {
+            return;
+        };
+        self.store_theme_preview(preset, lines, toc);
     }
 
     pub(crate) fn invalidate_theme_preview_cache(&mut self) {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,5 @@
 use anyhow::Result;
 
-use crate::theme::{parse_theme_preset, ThemePreset};
-
 #[derive(Debug, Default, PartialEq, Eq)]
 pub(crate) struct CliOptions {
     pub(crate) picker: bool,
@@ -12,7 +10,7 @@ pub(crate) struct CliOptions {
     pub(crate) print_help: bool,
     pub(crate) print_version: bool,
     pub(crate) file_arg: Option<String>,
-    pub(crate) theme: Option<ThemePreset>,
+    pub(crate) theme: Option<String>,
     pub(crate) editor: Option<String>,
 }
 
@@ -26,7 +24,7 @@ pub(crate) fn usage_text() -> &'static str {
      \x20 -h, --help                 Show this help message and exit\n\
      \x20 -V, --version              Show version information and exit\n\
      \x20 -w, --watch                Watch the file for changes and reload automatically\n\
-     \x20     --theme <PRESET>       Set color theme (arctic|forest|ocean|solarized-dark)\n\
+     \x20     --theme <NAME>         Set color theme preset or custom config theme\n\
      \x20 -e, --editor <NAME>        Set external editor (nano|vim|code|subl|emacs)\n\
      \x20     --picker               Open the file browser picker\n\
      \x20     --config               Open configuration file in editor\n\
@@ -72,17 +70,11 @@ pub(crate) fn parse_cli(args: &[String]) -> Result<CliOptions> {
                 let Some(name) = iter.next() else {
                     anyhow::bail!("Missing value for --theme");
                 };
-                options.theme = Some(
-                    parse_theme_preset(name)
-                        .ok_or_else(|| anyhow::anyhow!("Unknown theme: {name}"))?,
-                );
+                options.theme = Some(parse_theme_name(name)?);
             }
             _ if arg.starts_with("--theme=") => {
                 let name = &arg["--theme=".len()..];
-                options.theme = Some(
-                    parse_theme_preset(name)
-                        .ok_or_else(|| anyhow::anyhow!("Unknown theme: {name}"))?,
-                );
+                options.theme = Some(parse_theme_name(name)?);
             }
             "--editor" | "-e" => {
                 let Some(value) = iter.next() else {
@@ -134,4 +126,12 @@ pub(crate) fn parse_cli(args: &[String]) -> Result<CliOptions> {
     }
 
     Ok(options)
+}
+
+fn parse_theme_name(name: &str) -> Result<String> {
+    let name = name.trim();
+    if name.is_empty() {
+        anyhow::bail!("Missing value for --theme");
+    }
+    Ok(name.to_string())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,12 @@
-use std::path::{Path, PathBuf};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
 
 use anyhow::Context;
 use serde::Deserialize;
+
+use crate::theme::{resolve_theme_selection, CustomThemeConfig};
 
 const DEFAULT_CONFIG: &str = include_str!("../config.toml");
 
@@ -11,6 +16,9 @@ pub(crate) struct LeafConfig {
     pub(crate) theme: Option<String>,
     pub(crate) editor: Option<String>,
     pub(crate) watch: Option<bool>,
+    pub(crate) themes: BTreeMap<String, CustomThemeConfig>,
+    #[serde(skip)]
+    pub(crate) config_dir: Option<PathBuf>,
 }
 
 pub(crate) fn load_config() -> (LeafConfig, Option<String>) {
@@ -21,7 +29,7 @@ pub(crate) fn load_config() -> (LeafConfig, Option<String>) {
         Ok(c) => c,
         Err(_) => return (LeafConfig::default(), None),
     };
-    let config = match toml::from_str::<LeafConfig>(&content) {
+    let mut config = match toml::from_str::<LeafConfig>(&content) {
         Ok(c) => c,
         Err(_) => {
             return (
@@ -30,11 +38,14 @@ pub(crate) fn load_config() -> (LeafConfig, Option<String>) {
             );
         }
     };
-    let warning = config.theme.as_deref().and_then(|name| {
-        crate::theme::parse_theme_preset(name)
-            .is_none()
-            .then(|| format!("Unknown theme \"{name}\" in config, using default"))
-    });
+    config.config_dir = path.parent().map(Path::to_path_buf);
+    let warning = config
+        .theme
+        .as_deref()
+        .and_then(|name| {
+            resolve_theme_selection(name, &config.themes, config.config_dir.as_deref()).err()
+        })
+        .map(|message| format!("{message} in config, using default"));
     (config, warning)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,9 @@ use cli::{parse_cli, print_usage, print_version, CliOptions};
 use markdown::{hash_str, parse_markdown, read_file_state};
 use runtime::run;
 use terminal::{finish_with_restore, TerminalSession};
-use theme::{current_syntect_theme, parse_theme_preset, set_theme_preset};
+use theme::{
+    current_syntect_theme, resolve_theme_selection, set_theme_selection, validate_theme_syntax,
+};
 use update::run_update;
 
 const MAX_STDIN_BYTES: usize = 8 * 1024 * 1024;
@@ -43,7 +45,10 @@ pub(crate) use render::wrap_path_lines;
 #[cfg(test)]
 pub(crate) use runtime::should_handle_key;
 #[cfg(test)]
-pub(crate) use theme::{theme_preset_label, ThemePreset, THEME_PRESETS};
+pub(crate) use theme::{
+    app_theme, parse_theme_color, parse_theme_preset, theme_preset_label, CustomThemeConfig,
+    ThemePreset, ThemeSelection, THEME_PRESETS,
+};
 #[cfg(test)]
 pub(crate) use update::{
     asset_name_for_target, expected_asset_download_url, find_expected_checksum, is_newer_version,
@@ -67,6 +72,19 @@ fn read_stdin_limited<R: Read>(reader: &mut R, max_bytes: usize) -> Result<Strin
         );
     }
     String::from_utf8(buf).context("stdin is not valid UTF-8")
+}
+
+fn append_config_warning(warning: &mut Option<String>, next: Option<String>) {
+    let Some(next) = next else {
+        return;
+    };
+    match warning {
+        Some(existing) => {
+            existing.push_str("; ");
+            existing.push_str(&next);
+        }
+        None => *warning = Some(next),
+    }
 }
 
 fn main() -> Result<()> {
@@ -99,18 +117,27 @@ fn main() -> Result<()> {
         ..
     } = options;
 
-    let (user_config, config_warning) = config::load_config();
+    let (user_config, mut config_warning) = config::load_config();
 
-    let theme = cli_theme
-        .or_else(|| user_config.theme.as_deref().and_then(parse_theme_preset))
-        .unwrap_or_default();
+    let theme_selection = if let Some(theme_name) = cli_theme.as_deref() {
+        resolve_theme_selection(theme_name, &user_config.themes, None)
+            .map_err(|message| anyhow::anyhow!("{message}"))?
+    } else if let Some(theme_name) = user_config.theme.as_deref() {
+        resolve_theme_selection(
+            theme_name,
+            &user_config.themes,
+            user_config.config_dir.as_deref(),
+        )
+        .unwrap_or_default()
+    } else {
+        theme::ThemeSelection::default()
+    };
 
     let watch_from_config = user_config.watch.unwrap_or(false);
 
     let resolved_editor =
         editor::resolve_editor(cli_editor.as_deref(), user_config.editor.as_deref());
     runtime::debug_log(debug_input, &format!("main start args={args:?}"));
-    set_theme_preset(theme);
 
     if debug_input {
         let mut file = OpenOptions::new()
@@ -162,6 +189,11 @@ fn main() -> Result<()> {
 
     let ss = SyntaxSet::load_defaults_newlines();
     let ts = ThemeSet::load_defaults();
+    append_config_warning(
+        &mut config_warning,
+        validate_theme_syntax(&theme_selection, &ts),
+    );
+    set_theme_selection(theme_selection);
     let theme = current_syntect_theme(&ts).clone();
     runtime::debug_log(
         debug_input,

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -101,7 +101,8 @@ pub(crate) fn hash_file_contents(path: &PathBuf) -> io::Result<u64> {
 }
 
 pub(crate) fn highlight_line<'a>(line: &Line<'a>) -> Line<'a> {
-    let theme = &app_theme().markdown;
+    let app_theme = app_theme();
+    let theme = &app_theme.markdown;
     Line::from(
         line.spans
             .iter()
@@ -249,7 +250,8 @@ fn highlight_code(
 }
 
 fn block_prefix(in_bq: bool) -> Vec<Span<'static>> {
-    let theme = &app_theme().markdown;
+    let app_theme = app_theme();
+    let theme = &app_theme.markdown;
     if in_bq {
         vec![Span::styled(
             "▏ ",
@@ -265,7 +267,8 @@ fn list_item_prefix(
     list_stack: &[ListKind],
     item_stack: &mut [ItemState],
 ) -> Vec<Span<'static>> {
-    let theme = &app_theme().markdown;
+    let app_theme = app_theme();
+    let theme = &app_theme.markdown;
     let mut prefix = block_prefix(in_bq);
     let Some(item) = item_stack.last_mut() else {
         return prefix;
@@ -1047,7 +1050,8 @@ pub(crate) fn parse_markdown_with_width(
     theme: &Theme,
     render_width: usize,
 ) -> (Vec<Line<'static>>, Vec<TocEntry>) {
-    let theme_colors = &app_theme().markdown;
+    let app_theme = app_theme();
+    let theme_colors = &app_theme.markdown;
     let (src, fm_pairs) = frontmatter::extract_frontmatter(src);
     let mut lines: Vec<Line<'static>> = Vec::new();
 

--- a/src/markdown/tables.rs
+++ b/src/markdown/tables.rs
@@ -305,7 +305,8 @@ impl TableBuf {
     }
 
     pub(crate) fn render(&self, render_width: usize) -> Vec<Line<'static>> {
-        let theme = &app_theme().markdown;
+        let app_theme = app_theme();
+        let theme = &app_theme.markdown;
         if self.rows.is_empty() {
             return vec![];
         }

--- a/src/render/popup.rs
+++ b/src/render/popup.rs
@@ -195,7 +195,7 @@ pub(super) fn render_theme_popup(f: &mut Frame, app: &App) {
     ];
     for (idx, preset) in THEME_PRESETS.iter().enumerate() {
         let selected = idx == app.theme_picker_index();
-        let is_active = *preset == active;
+        let is_active = active == Some(*preset);
         let bg = if selected {
             theme.ui.toc_active_bg
         } else {

--- a/src/tests/app.rs
+++ b/src/tests/app.rs
@@ -121,6 +121,28 @@ fn parse_cli_accepts_picker_with_watch() {
 }
 
 #[test]
+fn parse_cli_accepts_custom_theme_names() {
+    let args = vec![
+        "leaf".to_string(),
+        "--theme".to_string(),
+        "my-theme".to_string(),
+        "README.md".to_string(),
+    ];
+
+    let options = parse_cli(&args).unwrap();
+    assert_eq!(options.theme.as_deref(), Some("my-theme"));
+    assert_eq!(options.file_arg.as_deref(), Some("README.md"));
+}
+
+#[test]
+fn parse_cli_rejects_empty_theme_name() {
+    let args = vec!["leaf".to_string(), "--theme=".to_string()];
+
+    let err = parse_cli(&args).unwrap_err();
+    assert!(err.to_string().contains("Missing value for --theme"));
+}
+
+#[test]
 fn cancelling_search_clears_query_and_matches() {
     let (ss, theme) = test_assets();
     let (lines, toc) = parse_markdown("alpha\nbeta\nalpha beta\n", &ss, &theme);

--- a/src/tests/config.rs
+++ b/src/tests/config.rs
@@ -11,6 +11,7 @@ watch = true
     assert_eq!(config.theme.as_deref(), Some("forest"));
     assert_eq!(config.editor.as_deref(), Some("vim"));
     assert_eq!(config.watch, Some(true));
+    assert!(config.themes.is_empty());
 }
 
 #[test]
@@ -20,6 +21,7 @@ fn parse_partial_config_theme_only() {
     assert_eq!(config.theme.as_deref(), Some("arctic"));
     assert_eq!(config.editor, None);
     assert_eq!(config.watch, None);
+    assert!(config.themes.is_empty());
 }
 
 #[test]
@@ -29,6 +31,7 @@ fn parse_empty_config() {
     assert_eq!(config.theme, None);
     assert_eq!(config.editor, None);
     assert_eq!(config.watch, None);
+    assert!(config.themes.is_empty());
 }
 
 #[test]
@@ -40,6 +43,7 @@ fn parse_invalid_toml_returns_default() {
     assert_eq!(fallback.theme, None);
     assert_eq!(fallback.editor, None);
     assert_eq!(fallback.watch, None);
+    assert!(fallback.themes.is_empty());
 }
 
 #[test]
@@ -58,6 +62,97 @@ fn invalid_theme_is_not_a_known_preset() {
     let config: LeafConfig = toml::from_str(toml).unwrap();
     assert_eq!(config.theme.as_deref(), Some("nonexistent"));
     assert!(parse_theme_preset("nonexistent").is_none());
+}
+
+#[test]
+fn parse_custom_theme_config() {
+    let toml = r##"
+theme = "my-theme"
+
+[themes.my-theme]
+base = "forest"
+syntax = "base16-ocean.dark"
+
+[themes.my-theme.ui]
+content_bg = "#101010"
+
+[themes.my-theme.markdown]
+text = [220, 221, 222]
+"##;
+    let config: LeafConfig = toml::from_str(toml).unwrap();
+    let selection = crate::theme::resolve_theme_selection(
+        config.theme.as_deref().unwrap(),
+        &config.themes,
+        None,
+    )
+    .unwrap();
+
+    let ThemeSelection::Custom(custom) = selection else {
+        panic!("expected custom theme");
+    };
+
+    assert_eq!(custom.name, "my-theme");
+    assert_eq!(custom.base_preset, ThemePreset::Forest);
+    assert_eq!(
+        custom.theme.ui.content_bg,
+        ratatui::style::Color::Rgb(16, 16, 16)
+    );
+    assert_eq!(
+        custom.theme.markdown.text,
+        ratatui::style::Color::Rgb(220, 221, 222)
+    );
+}
+
+#[test]
+fn repository_config_keeps_ocean_default() {
+    let config: LeafConfig = toml::from_str(include_str!("../../config.toml")).unwrap();
+    assert_eq!(config.theme.as_deref(), Some("ocean"));
+    assert!(config.themes.is_empty());
+}
+
+#[test]
+fn external_theme_file_resolves_relative_to_config_dir() {
+    let dir = super::unique_temp_dir("leaf-theme-config");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("gruvbox.toml"),
+        r##"
+base = "ocean"
+syntax = "base16-ocean.dark"
+
+[ui]
+content_bg = "#282828"
+
+[markdown]
+text = "#ebdbb2"
+heading_1 = "#fabd2f"
+"##,
+    )
+    .unwrap();
+
+    let themes = std::collections::BTreeMap::new();
+    let selection =
+        crate::theme::resolve_theme_selection("gruvbox.toml", &themes, Some(&dir)).unwrap();
+    std::fs::remove_dir_all(&dir).unwrap();
+
+    let ThemeSelection::Custom(custom) = selection else {
+        panic!("expected gruvbox to resolve as a custom theme");
+    };
+
+    assert_eq!(custom.name, "gruvbox");
+    assert_eq!(custom.base_preset, ThemePreset::OceanDark);
+    assert_eq!(
+        custom.theme.ui.content_bg,
+        ratatui::style::Color::Rgb(40, 40, 40)
+    );
+    assert_eq!(
+        custom.theme.markdown.text,
+        ratatui::style::Color::Rgb(235, 219, 178)
+    );
+    assert_eq!(
+        custom.theme.markdown.heading_1,
+        ratatui::style::Color::Rgb(250, 189, 47)
+    );
 }
 
 #[test]

--- a/src/tests/markdown.rs
+++ b/src/tests/markdown.rs
@@ -483,7 +483,8 @@ fn table_inline_code_has_code_style() {
     let (ss, theme) = test_assets();
     let md = "| A |\n|---|\n| `code` |\n";
     let (lines, _) = parse_markdown(md, &ss, &theme);
-    let theme_colors = &app_theme().markdown;
+    let app_theme = app_theme();
+    let theme_colors = &app_theme.markdown;
 
     let has_code_span = lines.iter().any(|line| {
         line.spans.iter().any(|span| {
@@ -501,7 +502,8 @@ fn table_inline_code_has_padding() {
     let (ss, theme) = test_assets();
     let md = "| A |\n|---|\n| `x` |\n";
     let (lines, _) = parse_markdown(md, &ss, &theme);
-    let theme_colors = &app_theme().markdown;
+    let app_theme = app_theme();
+    let theme_colors = &app_theme.markdown;
 
     let has_padded_span = lines.iter().any(|line| {
         line.spans
@@ -519,7 +521,8 @@ fn table_inline_math_renders_with_latex_style() {
     let (ss, theme) = test_assets();
     let md = "| A |\n|---|\n| $\\alpha$ |\n";
     let (lines, _) = parse_markdown(md, &ss, &theme);
-    let theme_colors = &app_theme().markdown;
+    let app_theme = app_theme();
+    let theme_colors = &app_theme.markdown;
 
     let has_math_span = lines.iter().any(|line| {
         line.spans.iter().any(|span| {
@@ -537,7 +540,8 @@ fn table_mixed_text_and_code_renders_both_styles() {
     let (ss, theme) = test_assets();
     let md = "| A |\n|---|\n| hello `world` bye |\n";
     let (lines, _) = parse_markdown(md, &ss, &theme);
-    let theme_colors = &app_theme().markdown;
+    let app_theme = app_theme();
+    let theme_colors = &app_theme.markdown;
 
     let table_line = lines
         .iter()
@@ -794,7 +798,8 @@ fn blockquote_bold_link_preserves_link_color() {
     let (ss, theme) = test_assets();
     let src = "> text [**lien bold**](https://rivolink.mg)\n";
     let (lines, _) = parse_markdown(src, &ss, &theme);
-    let theme_colors = &app_theme().markdown;
+    let app_theme = app_theme();
+    let theme_colors = &app_theme.markdown;
 
     let bq_line = &lines[0];
     let link_span = bq_line.spans.iter().find(|s| s.content.as_ref() == "lien");

--- a/src/tests/theme.rs
+++ b/src/tests/theme.rs
@@ -1,8 +1,13 @@
 use super::{lock_theme_test_state, test_assets};
 use crate::app::{App, AppConfig};
 use crate::markdown::parse_markdown;
-use crate::theme::{current_theme_preset, set_theme_preset, theme_preset_index};
+use crate::theme::{
+    current_syntect_theme, current_theme_preset, current_theme_selection, resolve_theme_selection,
+    set_theme_preset, set_theme_selection, theme_preset_index, validate_theme_syntax,
+};
 use crate::*;
+use ratatui::style::Color;
+use std::collections::BTreeMap;
 use syntect::highlighting::ThemeSet;
 
 #[test]
@@ -15,6 +20,93 @@ fn parse_theme_preset_supports_ocean_and_forest() {
         Some(ThemePreset::SolarizedDark)
     );
     assert_eq!(parse_theme_preset("nope"), None);
+}
+
+#[test]
+fn parse_theme_color_supports_hex_rgb_arrays_and_names() {
+    assert_eq!(parse_theme_color("#112233"), Some(Color::Rgb(17, 34, 51)));
+    assert_eq!(parse_theme_color("abc"), Some(Color::Rgb(170, 187, 204)));
+    assert_eq!(parse_theme_color("rgb(1, 2, 3)"), Some(Color::Rgb(1, 2, 3)));
+    assert_eq!(parse_theme_color("light-blue"), Some(Color::LightBlue));
+    assert_eq!(parse_theme_color("not-a-color"), None);
+}
+
+#[test]
+fn resolve_theme_selection_supports_custom_theme_overrides() {
+    let custom: CustomThemeConfig = toml::from_str(
+        r##"
+base = "arctic"
+syntax = "InspiredGitHub"
+
+[ui]
+content_bg = "#112233"
+
+[markdown]
+heading_1 = [1, 2, 3]
+"##,
+    )
+    .unwrap();
+    let mut themes = BTreeMap::new();
+    themes.insert("midnight".to_string(), custom);
+
+    let selection = resolve_theme_selection("midnight", &themes, None).unwrap();
+    let ThemeSelection::Custom(custom) = selection else {
+        panic!("expected custom theme selection");
+    };
+
+    assert_eq!(custom.name, "midnight");
+    assert_eq!(custom.base_preset, ThemePreset::Arctic);
+    assert_eq!(custom.theme.syntax_theme_name.as_ref(), "InspiredGitHub");
+    assert_eq!(custom.theme.ui.content_bg, Color::Rgb(17, 34, 51));
+    assert_eq!(custom.theme.markdown.heading_1, Color::Rgb(1, 2, 3));
+    assert_eq!(
+        custom.theme.markdown.heading_2,
+        crate::theme::theme_by_preset(ThemePreset::Arctic)
+            .markdown
+            .heading_2
+    );
+}
+
+#[test]
+fn resolve_theme_selection_rejects_unknown_custom_base() {
+    let custom: CustomThemeConfig = toml::from_str(r#"base = "missing""#).unwrap();
+    let mut themes = BTreeMap::new();
+    themes.insert("broken".to_string(), custom);
+
+    let err = resolve_theme_selection("broken", &themes, None).unwrap_err();
+    assert!(err.contains("Unknown base theme \"missing\""));
+}
+
+#[test]
+fn validate_theme_syntax_warns_for_unknown_syntect_theme() {
+    let custom: CustomThemeConfig = toml::from_str(r#"syntax = "missing-syntax-theme""#).unwrap();
+    let mut themes = BTreeMap::new();
+    themes.insert("custom".to_string(), custom);
+    let selection = resolve_theme_selection("custom", &themes, None).unwrap();
+    let theme_set = ThemeSet::load_defaults();
+
+    let warning = validate_theme_syntax(&selection, &theme_set).unwrap();
+    assert!(warning.contains("missing-syntax-theme"));
+}
+
+#[test]
+fn set_theme_selection_applies_custom_theme() {
+    let _guard = lock_theme_test_state();
+    let original = current_theme_selection();
+    let custom: CustomThemeConfig = toml::from_str(
+        r##"[markdown]
+text = "#010203"
+"##,
+    )
+    .unwrap();
+    let mut themes = BTreeMap::new();
+    themes.insert("custom".to_string(), custom);
+    let selection = resolve_theme_selection("custom", &themes, None).unwrap();
+
+    set_theme_selection(selection);
+
+    assert_eq!(app_theme().markdown.text, Color::Rgb(1, 2, 3));
+    set_theme_selection(original);
 }
 
 #[test]
@@ -47,7 +139,7 @@ fn theme_picker_restores_original_preset_on_escape() {
         },
     );
 
-    let original = current_theme_preset();
+    let original = current_theme_selection();
     set_theme_preset(ThemePreset::OceanDark);
     app.open_theme_picker();
     assert!(app.set_theme_picker_index(theme_preset_index(ThemePreset::Forest)));
@@ -60,7 +152,7 @@ fn theme_picker_restores_original_preset_on_escape() {
     assert_eq!(current_theme_preset(), ThemePreset::OceanDark);
     assert!(!app.is_theme_picker_open());
     assert_eq!(app.theme_picker_original(), None);
-    set_theme_preset(original);
+    set_theme_selection(original);
 }
 
 #[test]
@@ -82,7 +174,7 @@ fn theme_picker_caches_previewed_themes_for_reuse() {
         },
     );
 
-    let original = current_theme_preset();
+    let original = current_theme_selection();
     set_theme_preset(ThemePreset::OceanDark);
     app.open_theme_picker();
     app.preview_theme_preset(ThemePreset::Forest, &ss, &ts);
@@ -93,5 +185,54 @@ fn theme_picker_caches_previewed_themes_for_reuse() {
     app.preview_theme_preset(ThemePreset::OceanDark, &ss, &ts);
     assert_eq!(current_theme_preset(), ThemePreset::OceanDark);
     assert!(app.has_cached_theme_preview(ThemePreset::OceanDark));
-    set_theme_preset(original);
+    set_theme_selection(original);
+}
+
+#[test]
+fn theme_picker_restores_custom_theme_on_escape() {
+    let _guard = lock_theme_test_state();
+    let original = current_theme_selection();
+    let custom: CustomThemeConfig = toml::from_str(
+        r##"
+base = "ocean"
+
+[markdown]
+heading_1 = "#010203"
+"##,
+    )
+    .unwrap();
+    let mut themes = BTreeMap::new();
+    themes.insert("custom".to_string(), custom);
+    let custom_selection = resolve_theme_selection("custom", &themes, None).unwrap();
+    set_theme_selection(custom_selection.clone());
+
+    let ss = syntect::parsing::SyntaxSet::load_defaults_newlines();
+    let ts = ThemeSet::load_defaults();
+    let theme = current_syntect_theme(&ts).clone();
+    let (lines, toc) = parse_markdown("# Demo\n", &ss, &theme);
+    let mut app = App::new_with_source(
+        lines,
+        toc,
+        AppConfig {
+            filename: "stdin".to_string(),
+            source: "# Demo\n".to_string(),
+            debug_input: false,
+            watch: false,
+            filepath: None,
+            last_file_state: None,
+        },
+    );
+
+    app.open_theme_picker();
+    app.preview_theme_preset(ThemePreset::Forest, &ss, &ts);
+    assert_eq!(
+        current_theme_selection().as_preset(),
+        Some(ThemePreset::Forest)
+    );
+
+    app.restore_theme_picker_preview(&ss, &ts);
+
+    assert_eq!(current_theme_selection(), custom_selection);
+    assert_eq!(app_theme().markdown.heading_1, Color::Rgb(1, 2, 3));
+    set_theme_selection(original);
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,5 +1,15 @@
 use ratatui::style::Color;
-use std::sync::atomic::{AtomicU8, Ordering};
+use serde::{
+    de::{Error as DeError, SeqAccess, Visitor},
+    Deserialize, Deserializer,
+};
+use std::{
+    borrow::Cow,
+    collections::BTreeMap,
+    fmt,
+    path::{Path, PathBuf},
+    sync::RwLock,
+};
 use syntect::{highlighting::Theme, highlighting::ThemeSet};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -17,14 +27,14 @@ impl Default for ThemePreset {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct AppTheme {
-    pub(crate) syntax_theme_name: &'static str,
+    pub(crate) syntax_theme_name: Cow<'static, str>,
     pub(crate) ui: UiTheme,
     pub(crate) markdown: MarkdownTheme,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct UiTheme {
     pub(crate) toc_bg: Color,
     pub(crate) toc_border: Color,
@@ -61,7 +71,7 @@ pub(crate) struct UiTheme {
     pub(crate) toc_secondary_text_inactive: Color,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct MarkdownTheme {
     pub(crate) search_highlight_bg: Color,
     pub(crate) code_gutter: Color,
@@ -246,13 +256,13 @@ const BASE_DARK_MARKDOWN: MarkdownTheme = MarkdownTheme {
 };
 
 pub(crate) const ARCTIC_THEME: AppTheme = AppTheme {
-    syntax_theme_name: "base16-ocean.light",
+    syntax_theme_name: Cow::Borrowed("base16-ocean.light"),
     ui: BASE_LIGHT_UI,
     markdown: BASE_LIGHT_MARKDOWN,
 };
 
 pub(crate) const FOREST_THEME: AppTheme = AppTheme {
-    syntax_theme_name: "InspiredGitHub",
+    syntax_theme_name: Cow::Borrowed("InspiredGitHub"),
     ui: UiTheme {
         toc_bg: Color::Rgb(16, 22, 18),
         toc_border: Color::Rgb(50, 66, 54),
@@ -327,13 +337,13 @@ pub(crate) const FOREST_THEME: AppTheme = AppTheme {
 };
 
 pub(crate) const OCEAN_DARK_THEME: AppTheme = AppTheme {
-    syntax_theme_name: "base16-ocean.dark",
+    syntax_theme_name: Cow::Borrowed("base16-ocean.dark"),
     ui: BASE_DARK_UI,
     markdown: BASE_DARK_MARKDOWN,
 };
 
 pub(crate) const SOLARIZED_DARK_THEME: AppTheme = AppTheme {
-    syntax_theme_name: "Solarized (dark)",
+    syntax_theme_name: Cow::Borrowed("Solarized (dark)"),
     ui: UiTheme {
         toc_bg: Color::Rgb(7, 54, 66),
         toc_border: Color::Rgb(88, 110, 117),
@@ -414,7 +424,223 @@ pub(crate) const THEME_PRESETS: [ThemePreset; 4] = [
     ThemePreset::OceanDark,
     ThemePreset::SolarizedDark,
 ];
-static CURRENT_PRESET: AtomicU8 = AtomicU8::new(DEFAULT_PRESET as u8);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CustomTheme {
+    pub(crate) name: String,
+    pub(crate) base_preset: ThemePreset,
+    pub(crate) theme: AppTheme,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ThemeSelection {
+    Preset(ThemePreset),
+    Custom(Box<CustomTheme>),
+}
+
+impl Default for ThemeSelection {
+    fn default() -> Self {
+        Self::Preset(DEFAULT_PRESET)
+    }
+}
+
+impl ThemeSelection {
+    pub(crate) fn as_preset(&self) -> Option<ThemePreset> {
+        match self {
+            Self::Preset(preset) => Some(*preset),
+            Self::Custom(_) => None,
+        }
+    }
+
+    pub(crate) fn preset_hint(&self) -> ThemePreset {
+        match self {
+            Self::Preset(preset) => *preset,
+            Self::Custom(custom) => custom.base_preset,
+        }
+    }
+
+    pub(crate) fn app_theme(&self) -> AppTheme {
+        match self {
+            Self::Preset(preset) => theme_by_preset(*preset).clone(),
+            Self::Custom(custom) => custom.theme.clone(),
+        }
+    }
+
+    pub(crate) fn syntax_theme_name(&self) -> &str {
+        match self {
+            Self::Preset(preset) => theme_by_preset(*preset).syntax_theme_name.as_ref(),
+            Self::Custom(custom) => custom.theme.syntax_theme_name.as_ref(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ThemeColor(pub(crate) Color);
+
+impl<'de> Deserialize<'de> for ThemeColor {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ColorVisitor;
+
+        impl<'de> Visitor<'de> for ColorVisitor {
+            type Value = ThemeColor;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a color name, hex color string, rgb(...) string, or [r, g, b]")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                parse_theme_color(value)
+                    .map(ThemeColor)
+                    .ok_or_else(|| E::custom(format!("invalid theme color: {value}")))
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+            where
+                E: DeError,
+            {
+                self.visit_str(&value)
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let r = read_rgb_component(&mut seq, "red")?;
+                let g = read_rgb_component(&mut seq, "green")?;
+                let b = read_rgb_component(&mut seq, "blue")?;
+                if seq.next_element::<u16>()?.is_some() {
+                    return Err(A::Error::custom(
+                        "theme RGB array must contain exactly 3 values",
+                    ));
+                }
+                Ok(ThemeColor(Color::Rgb(r, g, b)))
+            }
+        }
+
+        deserializer.deserialize_any(ColorVisitor)
+    }
+}
+
+fn read_rgb_component<'de, A>(seq: &mut A, name: &str) -> Result<u8, A::Error>
+where
+    A: SeqAccess<'de>,
+{
+    let value = seq
+        .next_element::<u16>()?
+        .ok_or_else(|| A::Error::custom(format!("missing {name} theme color component")))?;
+    u8::try_from(value)
+        .map_err(|_| A::Error::custom(format!("{name} theme color component out of range")))
+}
+
+macro_rules! theme_overrides {
+    ($name:ident for $theme:ty { $($field:ident),+ $(,)? }) => {
+        #[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
+        #[serde(default)]
+        pub(crate) struct $name {
+            $(pub(crate) $field: Option<ThemeColor>,)+
+        }
+
+        impl $name {
+            fn apply_to(&self, theme: &mut $theme) {
+                $(
+                    if let Some(color) = self.$field {
+                        theme.$field = color.0;
+                    }
+                )+
+            }
+        }
+    };
+}
+
+theme_overrides!(UiThemeOverrides for UiTheme {
+    toc_bg,
+    toc_border,
+    content_bg,
+    scrollbar_hover,
+    status_bg,
+    status_separator,
+    status_brand_fg,
+    status_brand_bg,
+    status_filename_fg,
+    status_filename_bg,
+    status_watch_fg,
+    status_watch_bg,
+    status_reloaded_fg,
+    status_reloaded_bg,
+    status_search_fg,
+    status_search_bg,
+    status_success_fg,
+    status_success_bg,
+    status_warning_fg,
+    status_error_fg,
+    status_error_bg,
+    status_shortcut_fg,
+    status_percent_fg,
+    toc_header_fg,
+    toc_active_bg,
+    toc_inactive_bg,
+    toc_accent,
+    toc_index_inactive,
+    toc_primary_active,
+    toc_primary_inactive,
+    toc_secondary_inactive,
+    toc_secondary_text_active,
+    toc_secondary_text_inactive,
+});
+
+theme_overrides!(MarkdownThemeOverrides for MarkdownTheme {
+    search_highlight_bg,
+    code_gutter,
+    blockquote_marker,
+    list_level_1,
+    list_level_2,
+    list_level_3,
+    ordered_list,
+    table_border,
+    table_separator,
+    table_header,
+    table_cell,
+    heading_1,
+    heading_2,
+    heading_3,
+    heading_4,
+    heading_other,
+    heading_underline,
+    code_frame,
+    code_label,
+    inline_code_fg,
+    inline_code_bg,
+    rule,
+    link_icon,
+    link_text,
+    blockquote_text,
+    text,
+    strong_text,
+    latex_inline_fg,
+    latex_inline_bg,
+    latex_block_fg,
+    mermaid_keyword,
+    mermaid_arrow,
+    mermaid_label,
+    mermaid_block_fg,
+});
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub(crate) struct CustomThemeConfig {
+    pub(crate) base: Option<String>,
+    pub(crate) syntax: Option<String>,
+    pub(crate) ui: UiThemeOverrides,
+    pub(crate) markdown: MarkdownThemeOverrides,
+}
+
+static CURRENT_THEME: RwLock<ThemeSelection> = RwLock::new(ThemeSelection::Preset(DEFAULT_PRESET));
 
 pub(crate) fn parse_theme_preset(name: &str) -> Option<ThemePreset> {
     match name {
@@ -424,6 +650,168 @@ pub(crate) fn parse_theme_preset(name: &str) -> Option<ThemePreset> {
         "solarized" | "solarized-dark" => Some(ThemePreset::SolarizedDark),
         _ => None,
     }
+}
+
+pub(crate) fn parse_theme_color(value: &str) -> Option<Color> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+
+    if let Some(color) = parse_hex_color(value) {
+        return Some(color);
+    }
+    if let Some(color) = parse_rgb_color(value) {
+        return Some(color);
+    }
+
+    match value.to_ascii_lowercase().as_str() {
+        "black" => Some(Color::Black),
+        "red" => Some(Color::Red),
+        "green" => Some(Color::Green),
+        "yellow" => Some(Color::Yellow),
+        "blue" => Some(Color::Blue),
+        "magenta" => Some(Color::Magenta),
+        "cyan" => Some(Color::Cyan),
+        "gray" | "grey" => Some(Color::Gray),
+        "dark-gray" | "dark-grey" => Some(Color::DarkGray),
+        "light-red" => Some(Color::LightRed),
+        "light-green" => Some(Color::LightGreen),
+        "light-yellow" => Some(Color::LightYellow),
+        "light-blue" => Some(Color::LightBlue),
+        "light-magenta" => Some(Color::LightMagenta),
+        "light-cyan" => Some(Color::LightCyan),
+        "white" => Some(Color::White),
+        _ => None,
+    }
+}
+
+fn parse_hex_color(value: &str) -> Option<Color> {
+    let hex = value.strip_prefix('#').unwrap_or(value);
+    match hex.len() {
+        3 if hex.chars().all(|c| c.is_ascii_hexdigit()) => {
+            let mut expanded = String::with_capacity(6);
+            for ch in hex.chars() {
+                expanded.push(ch);
+                expanded.push(ch);
+            }
+            parse_hex_color(&expanded)
+        }
+        6 if hex.chars().all(|c| c.is_ascii_hexdigit()) => {
+            let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+            let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+            let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+            Some(Color::Rgb(r, g, b))
+        }
+        _ => None,
+    }
+}
+
+fn parse_rgb_color(value: &str) -> Option<Color> {
+    let value = value.trim();
+    let inner = value.strip_prefix("rgb(")?.strip_suffix(')')?;
+    let mut components = inner.split(',').map(str::trim);
+    let r = components.next()?.parse::<u8>().ok()?;
+    let g = components.next()?.parse::<u8>().ok()?;
+    let b = components.next()?.parse::<u8>().ok()?;
+    if components.next().is_some() {
+        return None;
+    }
+    Some(Color::Rgb(r, g, b))
+}
+
+pub(crate) fn resolve_theme_selection(
+    name: &str,
+    custom_themes: &BTreeMap<String, CustomThemeConfig>,
+    theme_file_base_dir: Option<&Path>,
+) -> Result<ThemeSelection, String> {
+    let name = name.trim();
+    if name.is_empty() {
+        return Err("Theme name cannot be empty".to_string());
+    }
+
+    if let Some(preset) = parse_theme_preset(name) {
+        return Ok(ThemeSelection::Preset(preset));
+    }
+
+    if let Some(custom_config) = custom_themes.get(name) {
+        return custom_theme_selection(name, custom_config);
+    }
+
+    if looks_like_theme_file(name) {
+        return resolve_theme_file_selection(name, theme_file_base_dir);
+    }
+
+    Err(format!("Unknown theme \"{name}\""))
+}
+
+fn custom_theme_selection(
+    name: &str,
+    custom_config: &CustomThemeConfig,
+) -> Result<ThemeSelection, String> {
+    let base_preset = match custom_config.base.as_deref() {
+        Some(base) => parse_theme_preset(base)
+            .ok_or_else(|| format!("Unknown base theme \"{base}\" for custom theme \"{name}\""))?,
+        None => DEFAULT_PRESET,
+    };
+
+    let mut theme = theme_by_preset(base_preset).clone();
+    if let Some(syntax) = custom_config.syntax.as_deref() {
+        let syntax = syntax.trim();
+        if syntax.is_empty() {
+            return Err(format!("Empty syntax theme for custom theme \"{name}\""));
+        }
+        theme.syntax_theme_name = Cow::Owned(syntax.to_string());
+    }
+    custom_config.ui.apply_to(&mut theme.ui);
+    custom_config.markdown.apply_to(&mut theme.markdown);
+
+    Ok(ThemeSelection::Custom(Box::new(CustomTheme {
+        name: name.to_string(),
+        base_preset,
+        theme,
+    })))
+}
+
+fn looks_like_theme_file(name: &str) -> bool {
+    name.ends_with(".toml") || name.contains('/') || name.contains('\\')
+}
+
+fn resolve_theme_file_selection(
+    name: &str,
+    theme_file_base_dir: Option<&Path>,
+) -> Result<ThemeSelection, String> {
+    let path = resolve_theme_file_path(name, theme_file_base_dir);
+    let content = std::fs::read_to_string(&path)
+        .map_err(|err| format!("Cannot read theme file \"{}\": {err}", path.display()))?;
+    let custom_config = toml::from_str::<CustomThemeConfig>(&content)
+        .map_err(|err| format!("Could not parse theme file \"{}\": {err}", path.display()))?;
+    let theme_name = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|stem| !stem.is_empty())
+        .unwrap_or(name);
+    custom_theme_selection(theme_name, &custom_config)
+}
+
+fn resolve_theme_file_path(name: &str, theme_file_base_dir: Option<&Path>) -> PathBuf {
+    let path = Path::new(name);
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    theme_file_base_dir
+        .map(|base_dir| base_dir.join(path))
+        .unwrap_or_else(|| path.to_path_buf())
+}
+
+pub(crate) fn validate_theme_syntax(
+    selection: &ThemeSelection,
+    themes: &ThemeSet,
+) -> Option<String> {
+    let syntax_theme_name = selection.syntax_theme_name();
+    (!themes.themes.contains_key(syntax_theme_name)).then(|| {
+        format!("Unknown syntax theme \"{syntax_theme_name}\", using default syntax colors")
+    })
 }
 
 pub(crate) fn theme_preset_label(preset: ThemePreset) -> &'static str {
@@ -451,24 +839,40 @@ pub(crate) fn theme_by_preset(preset: ThemePreset) -> &'static AppTheme {
     }
 }
 
+pub(crate) fn set_theme_selection(selection: ThemeSelection) {
+    *CURRENT_THEME.write().expect("theme state lock poisoned") = selection;
+}
+
+pub(crate) fn current_theme_selection() -> ThemeSelection {
+    CURRENT_THEME
+        .read()
+        .expect("theme state lock poisoned")
+        .clone()
+}
+
 pub(crate) fn set_theme_preset(preset: ThemePreset) {
-    CURRENT_PRESET.store(preset as u8, Ordering::Relaxed);
+    set_theme_selection(ThemeSelection::Preset(preset));
 }
 
+#[cfg(test)]
 pub(crate) fn current_theme_preset() -> ThemePreset {
-    match CURRENT_PRESET.load(Ordering::Relaxed) {
-        0 => ThemePreset::Arctic,
-        1 => ThemePreset::Forest,
-        2 => ThemePreset::OceanDark,
-        3 => ThemePreset::SolarizedDark,
-        _ => DEFAULT_PRESET,
-    }
+    current_theme_selection().preset_hint()
 }
 
-pub(crate) fn app_theme() -> &'static AppTheme {
-    theme_by_preset(current_theme_preset())
+pub(crate) fn app_theme() -> AppTheme {
+    current_theme_selection().app_theme()
 }
 
 pub(crate) fn current_syntect_theme(themes: &ThemeSet) -> &Theme {
-    &themes.themes[app_theme().syntax_theme_name]
+    let theme = app_theme();
+    themes
+        .themes
+        .get(theme.syntax_theme_name.as_ref())
+        .or_else(|| {
+            themes
+                .themes
+                .get(theme_by_preset(DEFAULT_PRESET).syntax_theme_name.as_ref())
+        })
+        .or_else(|| themes.themes.values().next())
+        .expect("syntect theme set is empty")
 }


### PR DESCRIPTION
## Summary
- add config-driven custom themes with built-in preset inheritance, UI/Markdown color overrides, and optional syntax theme selection
- allow `--theme` / `theme` to select built-in presets, named inline custom themes, or external TOML theme files
- document external theme-file usage while keeping `config.toml` compact and preserving `ocean` as the default

## Validation
- `env -u LEAF_EDITOR -u VISUAL -u EDITOR cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`

## Notes
- Squashed to a single commit and removed the Copilot co-author trailer.
- Commit is SSH-signed with `lc@leocavalcante.com` and GitHub reports it as verified.