### PR TITLE
fix: verify SHA-256 checksum before installing binary

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -38,13 +38,40 @@ function Get-DownloadUrl {
     return "https://github.com/$Repo/releases/download/$Tag/$Asset"
 }
 
-function Install-Binary {
+function Download-Binary {
     param(
-        [string]$Url,
-        [string]$DestinationBin
+        [string]$Url
     )
 
-    Invoke-WebRequest -Uri $Url -OutFile $DestinationBin
+    $tempFile = [System.IO.Path]::GetTempFileName()
+    try {
+        Invoke-WebRequest -UseBasicParsing -Uri $Url -OutFile $tempFile
+        return $tempFile
+    } catch {
+        Remove-Item -Path $tempFile -Force -ErrorAction SilentlyContinue
+        throw
+    }
+}
+
+function Verify-Checksum {
+    param(
+        [string]$File,
+        [string]$ChecksumsUrl,
+        [string]$AssetName
+    )
+    $checksums = Invoke-RestMethod -Uri $ChecksumsUrl
+    $escapedName = [regex]::Escape($AssetName)
+    $line = ($checksums -split "\r?\n") |
+        Where-Object { $_ -match "\s${escapedName}$" } |
+        Select-Object -First 1
+    if (-not $line) {
+        throw "Checksum not found for $AssetName"
+    }
+    $expected = ($line -split '\s+')[0]
+    $actual = (Get-FileHash -Path $File -Algorithm SHA256).Hash.ToLower()
+    if ($actual -ne $expected) {
+        throw "Checksum mismatch!`nExpected: $expected`nGot:      $actual"
+    }
 }
 
 function Add-ToUserPath {
@@ -73,10 +100,33 @@ $destinationBin = Join-Path $destinationDir "leaf.exe"
 
 Ensure-InstallDir -Dir $destinationDir
 
+$currentVersion = $null
+if (Test-Path $destinationBin) {
+    try { $currentVersion = ((& $destinationBin --version 2>$null) -split ' ')[1] } catch {}
+}
+
+if ($currentVersion) {
+    Write-Info "Updating leaf..."
+} else {
+    Write-Info "Installing leaf..."
+}
+
 $tagName = Get-LatestTag -Repo $Repo
 $downloadUrl = Get-DownloadUrl -Repo $Repo -Tag $tagName -Asset $AssetName
 
-Install-Binary -Url $downloadUrl -DestinationBin $destinationBin
+$tempFile = Download-Binary -Url $downloadUrl
+try {
+    $checksumsUrl = Get-DownloadUrl -Repo $Repo -Tag $tagName -Asset "checksums.txt"
+    Verify-Checksum -File $tempFile -ChecksumsUrl $checksumsUrl -AssetName $AssetName
+    Copy-Item -Path $tempFile -Destination $destinationBin -Force
+} finally {
+    Remove-Item -Path $tempFile -Force -ErrorAction SilentlyContinue
+}
 Add-ToUserPath -Dir $destinationDir
 
-Write-Info "Installed leaf $tagName to $destinationBin"
+$newVersion = $tagName -replace '^v', ''
+if ($currentVersion) {
+    Write-Info "leaf updated from $currentVersion to $newVersion"
+} else {
+    Write-Info "leaf $newVersion installed"
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -113,16 +113,49 @@ if [ -z "$tag_name" ]; then
     exit 1
 fi
 
-download_url="https://github.com/$REPO/releases/download/$tag_name/$asset_name"
+current_version=""
+if [ -x "$DEST_BIN" ]; then
+    current_version="$("$DEST_BIN" --version 2>/dev/null | awk '{print $2}')" || true
+fi
+
+if [ -n "$current_version" ]; then
+    echo "Updating leaf..."
+else
+    echo "Installing leaf..."
+fi
+
+base_url="https://github.com/$REPO/releases/download/$tag_name"
 tmp_file="$(mktemp)"
-trap 'rm -f "$tmp_file"' EXIT
+tmp_checksums="$(mktemp)"
+trap 'rm -f "$tmp_file" "$tmp_checksums"' EXIT
 
 mkdir -p "$DEST_DIR"
-download_to "$download_url" "$tmp_file"
+download_to "$base_url/$asset_name" "$tmp_file"
+download_to "$base_url/checksums.txt" "$tmp_checksums"
+
+expected="$(grep "[[:space:]]${asset_name}$" "$tmp_checksums" | awk '{print $1}')"
+if [ -z "$expected" ]; then
+    echo "Asset $asset_name not found in checksums.txt" >&2
+    exit 1
+fi
+if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$tmp_file" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "$tmp_file" | awk '{print $1}')"
+else
+    echo "Missing sha256sum or shasum. Try: npm install -g @rivolink/leaf" >&2
+    exit 1
+fi
+[ "$actual" = "$expected" ] || { echo "Checksum mismatch for $asset_name" >&2; exit 1; }
+
 cp "$tmp_file" "$DEST_BIN"
 chmod 755 "$DEST_BIN"
 
-echo "Installed leaf $tag_name to $DEST_BIN"
+if [ -n "$current_version" ]; then
+    echo "leaf updated from $current_version to ${tag_name#v}"
+else
+    echo "leaf ${tag_name#v} installed"
+fi
 case ":$PATH:" in
     *:"$DEST_DIR":*)
         ;;


### PR DESCRIPTION
The install script downloaded the binary and copied it directly without verifying its integrity. The release workflow already publishes a checksums.txt file alongside each binary, so the data was available but unused.

Downloads checksums.txt and verifies the binary's SHA-256 hash before copying it to the destination. Aborts with a clear error on mismatch.