### PR TITLE
Bind another keys for up/down navigation in file picker

### DIFF
--- a/src/runtime/keyboard.rs
+++ b/src/runtime/keyboard.rs
@@ -84,7 +84,17 @@ pub(super) fn handle_key_event(
             KeyCode::Char('j') | KeyCode::Down if app.is_browser_file_picker() => {
                 app.move_file_picker_down()
             }
+            KeyCode::Char('j')
+                if key.modifiers.contains(KeyModifiers::CONTROL) && app.is_fuzzy_file_picker() =>
+            {
+                app.move_file_picker_down()
+            }
             KeyCode::Char('k') | KeyCode::Up if app.is_browser_file_picker() => {
+                app.move_file_picker_up()
+            }
+            KeyCode::Char('k')
+                if key.modifiers.contains(KeyModifiers::CONTROL) && app.is_fuzzy_file_picker() =>
+            {
                 app.move_file_picker_up()
             }
             KeyCode::Down if app.is_fuzzy_file_picker() => app.move_file_picker_down(),


### PR DESCRIPTION
HHKB keyboard users like me prefer to navigate using methods other than the arrow keys. 
Having used terminal user interface applications for many years, I believe this approach is a more common way to use such programs. 
Thank you for creating such a great application.
It’s okay if you reject this PR.
