### PR TITLE
chore: add cargo-binstall metadata for prebuilt binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,36 @@ version = "1.19.0"
 edition = "2021"
 description = "A friendly terminal Markdown previewer"
 license = "MIT"
+repository = "https://github.com/RivoLink/leaf"
 
 [[bin]]
 name = "leaf"
 path = "src/main.rs"
+
+[package.metadata.binstall]
+pkg-fmt = "bin"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/{ version }/leaf-linux-x86_64"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-musl]
+pkg-url = "{ repo }/releases/download/{ version }/leaf-linux-x86_64"
+
+[package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/{ version }/leaf-linux-arm64"
+
+[package.metadata.binstall.overrides.aarch64-unknown-linux-musl]
+pkg-url = "{ repo }/releases/download/{ version }/leaf-linux-arm64"
+
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{ repo }/releases/download/{ version }/leaf-macos-x86_64"
+
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{ repo }/releases/download/{ version }/leaf-macos-arm64"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/{ version }/leaf-windows-x86_64.exe"
+pkg-fmt = "bin"
 
 [dependencies]
 ratatui       = "0.29"


### PR DESCRIPTION
## Summary

Adds `[package.metadata.binstall]` and a `repository` field to `Cargo.toml` so [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall) can fetch the existing GitHub release binaries directly instead of falling back to `cargo install` (a from-source build).

Without this metadata, `cargo binstall leaf` either resolves to the unrelated abandoned `leaf` crate on crates.io (a 2016 deep-learning framework), or — when invoked via `cargo binstall --git https://github.com/RivoLink/leaf leaf` — fails to find a matching asset and falls back to compiling from source.

After this change:

```sh
cargo binstall --git https://github.com/RivoLink/leaf leaf
```

resolves the right release asset for the host target and installs the prebuilt binary into `~/.cargo/bin/leaf` in seconds.

## Changes

- Add `repository = "https://github.com/RivoLink/leaf"` to `[package]` so the `{ repo }` template variable is populated.
- Add `[package.metadata.binstall]` with `pkg-fmt = "bin"` (release assets are raw binaries, not archives).
- Add per-target `[package.metadata.binstall.overrides.*]` entries mapping each common Rust target triple to the matching release asset:
  - `x86_64-unknown-linux-{gnu,musl}` → `leaf-linux-x86_64`
  - `aarch64-unknown-linux-{gnu,musl}` → `leaf-linux-arm64`
  - `x86_64-apple-darwin` → `leaf-macos-x86_64`
  - `aarch64-apple-darwin` → `leaf-macos-arm64`
  - `x86_64-pc-windows-msvc` → `leaf-windows-x86_64.exe`

## Test plan

- [x] `cargo metadata --no-deps` parses the patched manifest without error.
- [x] `cargo binstall --manifest-path . --dry-run --force leaf` on `x86_64-unknown-linux-gnu` resolves the asset and reports `The package leaf v1.19.0 (x86_64-unknown-linux-gnu) has been downloaded from github.com`.
- [ ] Maintainer verifies on macOS / Windows targets if desired.

No runtime behavior changes; this only affects how `cargo-binstall` resolves the binary.