### PR TITLE
feat: add one-shot render mode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -56,6 +56,9 @@
 - `src/update.rs`
   - self-update: asset download, SHA256 verification, and binary replacement
 
+- `src/one_shot.rs`
+  - non-interactive stdout rendering for `--render`
+
 - `src/tests/`
   - `app.rs` — app state and mode detection tests
   - `file_picker.rs` — picker opening, fuzzy matching, sorting, truncation
@@ -72,18 +75,20 @@
    - a file argument, or
    - `stdin`, or
    - the file picker if no input is provided interactively.
-3. `markdown/` parses the source into rendered lines + TOC.
-4. `App` stores the state and caches.
-5. `runtime.rs` runs the event loop:
+3. In `--render` mode, `markdown/` parses width-aware content and `one_shot.rs` writes it to stdout before any terminal session starts.
+4. Otherwise, `markdown/` parses the source into rendered lines + TOC.
+5. `App` stores the state and caches.
+6. `runtime.rs` runs the event loop:
    - processes pending picker queue → spawns loading thread
    - polls picker loading → installs results when ready
    - handles input events through mode-aware branching
-6. `render/` draws each frame from `App`.
+7. `render/` draws each frame from `App`.
 
 ## Application modes
 
 - **Initial mode** (`!app.has_content()`): no file loaded, picker is the main view. Quit shortcuts exit the app.
 - **Preview mode** (`app.has_content()`): file loaded via argument, stdin, or picker selection. Quit shortcuts in pickers close the popup and return to the preview.
+- **One-shot render mode** (`--render`): document content is rendered to stdout and the process exits without creating an `App` or entering the terminal runtime.
 
 ## Picker lifecycle
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ claude "explain Rust lifetimes" | leaf
 # Preview a local file through stdin
 cat TESTING.md | leaf
 
+# Render Markdown once and print it to stdout
+leaf --render TESTING.md
+cat TESTING.md | leaf --render
+
+# Force styled or plain one-shot output
+leaf --render --ansi TESTING.md
+leaf --render --plain TESTING.md
+
 ```
 
 ## Configuration
@@ -206,7 +214,7 @@ See [`gruvbox.toml`](gruvbox.toml) for a complete example with all available col
 - **LaTeX support** — Inline, block, and `latex` / `tex` code blocks rendered as formulas.
 - **Navigation** — TOC sidebar, active section tracking, heading jumps, and search.
 - **Terminal UX** — Theme picker, help popup, file path popup, mouse and keyboard support.
-- **CLI friendly** — stdin support and `leaf --update` with SHA256 verification.
+- **CLI friendly** — stdin support, one-shot stdout rendering, and `leaf --update` with SHA256 verification.
 
 ## Typical AI Workflow
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,12 @@ cat TESTING.md | leaf --render
 leaf --render --ansi TESTING.md
 leaf --render --plain TESTING.md
 
+# Render at a fixed width, useful for redirects and scripts
+leaf --render --width 100 TESTING.md
+
 ```
+
+In `--render` mode, leaf uses the terminal width when stdout is a terminal and 80 columns when stdout is redirected or piped. Use `--width <COLS>` to override that width explicitly.
 
 ## Configuration
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -36,6 +36,7 @@ Render it once to stdout:
 ```bash
 leaf --render TESTING.md
 cat TESTING.md | leaf --render
+leaf --render --width 100 TESTING.md
 ```
 
 ## Manual Coverage
@@ -94,9 +95,11 @@ leaf --render TESTING.md
 cat TESTING.md | leaf --render
 leaf --render --ansi TESTING.md
 leaf --render --plain TESTING.md
+leaf --render --width 100 TESTING.md
 ```
 
 Confirm the rendered document content is printed directly, no picker opens, and the terminal does not enter raw mode or an alternate screen.
+When stdout is redirected or piped, confirm wrapping uses 80 columns unless `--width <COLS>` is provided.
 
 ### Startup And Error Handling
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -31,6 +31,13 @@ Open it through stdin:
 cat TESTING.md | leaf
 ```
 
+Render it once to stdout:
+
+```bash
+leaf --render TESTING.md
+cat TESTING.md | leaf --render
+```
+
 ## Manual Coverage
 
 Use the fixture in the `Manual Fixture` section of this file to verify the current feature set.
@@ -77,6 +84,19 @@ While running `cat TESTING.md | leaf`:
 
 - confirm the content matches file-backed rendering
 - confirm watch mode is not available
+
+### One-Shot Render Mode
+
+Run these checks manually:
+
+```bash
+leaf --render TESTING.md
+cat TESTING.md | leaf --render
+leaf --render --ansi TESTING.md
+leaf --render --plain TESTING.md
+```
+
+Confirm the rendered document content is printed directly, no picker opens, and the terminal does not enter raw mode or an alternate screen.
 
 ### Startup And Error Handling
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,7 +33,7 @@ pub(crate) fn usage_text() -> &'static str {
      \x20     --render               Render Markdown to stdout and exit\n\
      \x20     --ansi                 Force ANSI styling in --render output\n\
      \x20     --plain                Force plain text in --render output\n\
-     \x20     --width <COLS>         Set render output width\n\
+     \x20     --width <COLS>         Set --render output width\n\
      \x20     --theme <NAME>         Set color theme preset or custom config theme\n\
      \x20 -e, --editor <NAME>        Set external editor (nano|vim|code|subl|emacs)\n\
      \x20     --picker               Open the file browser picker\n\

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,6 +4,9 @@ use anyhow::Result;
 pub(crate) struct CliOptions {
     pub(crate) picker: bool,
     pub(crate) watch: bool,
+    pub(crate) render: bool,
+    pub(crate) ansi: bool,
+    pub(crate) plain: bool,
     pub(crate) update: bool,
     pub(crate) config: bool,
     pub(crate) debug_input: bool,
@@ -17,13 +20,18 @@ pub(crate) struct CliOptions {
 pub(crate) fn usage_text() -> &'static str {
     "Usage:  leaf [OPTIONS] [file.md]\n\
      \x20       leaf [--watch] --picker\n\
+     \x20       leaf --render [file.md]\n\
      \x20       leaf --update\n\
      \x20       echo '# Hello' | leaf\n\
+     \x20       echo '# Hello' | leaf --render\n\
      \n\
      Options:\n\
      \x20 -h, --help                 Show this help message and exit\n\
      \x20 -V, --version              Show version information and exit\n\
      \x20 -w, --watch                Watch the file for changes and reload automatically\n\
+     \x20     --render               Render Markdown to stdout and exit\n\
+     \x20     --ansi                 Force ANSI styling in --render output\n\
+     \x20     --plain                Force plain text in --render output\n\
      \x20     --theme <NAME>         Set color theme preset or custom config theme\n\
      \x20 -e, --editor <NAME>        Set external editor (nano|vim|code|subl|emacs)\n\
      \x20     --picker               Open the file browser picker\n\
@@ -61,6 +69,9 @@ pub(crate) fn parse_cli(args: &[String]) -> Result<CliOptions> {
         match arg.as_str() {
             "--picker" => options.picker = true,
             "--watch" | "-w" => options.watch = true,
+            "--render" => options.render = true,
+            "--ansi" => options.ansi = true,
+            "--plain" => options.plain = true,
             "--update" => options.update = true,
             "--config" => options.config = true,
             "--debug-input" => options.debug_input = true,
@@ -95,6 +106,9 @@ pub(crate) fn parse_cli(args: &[String]) -> Result<CliOptions> {
     if options.update {
         let has_non_update_flags = options.watch
             || options.picker
+            || options.render
+            || options.ansi
+            || options.plain
             || options.debug_input
             || options.config
             || options.file_arg.is_some()
@@ -108,6 +122,9 @@ pub(crate) fn parse_cli(args: &[String]) -> Result<CliOptions> {
     if options.config {
         let has_non_config_flags = options.watch
             || options.picker
+            || options.render
+            || options.ansi
+            || options.plain
             || options.debug_input
             || options.update
             || options.file_arg.is_some()
@@ -123,6 +140,25 @@ pub(crate) fn parse_cli(args: &[String]) -> Result<CliOptions> {
         if has_non_picker_flags {
             anyhow::bail!("--picker cannot be combined with a file path");
         }
+    }
+
+    if options.render {
+        if options.watch {
+            anyhow::bail!("--render cannot be combined with --watch");
+        }
+        if options.picker {
+            anyhow::bail!("--render cannot be combined with --picker");
+        }
+    }
+
+    if options.ansi && options.plain {
+        anyhow::bail!("--ansi and --plain cannot be combined");
+    }
+    if options.ansi && !options.render {
+        anyhow::bail!("--ansi requires --render");
+    }
+    if options.plain && !options.render {
+        anyhow::bail!("--plain requires --render");
     }
 
     Ok(options)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,6 +7,7 @@ pub(crate) struct CliOptions {
     pub(crate) render: bool,
     pub(crate) ansi: bool,
     pub(crate) plain: bool,
+    pub(crate) width: Option<usize>,
     pub(crate) update: bool,
     pub(crate) config: bool,
     pub(crate) debug_input: bool,
@@ -32,6 +33,7 @@ pub(crate) fn usage_text() -> &'static str {
      \x20     --render               Render Markdown to stdout and exit\n\
      \x20     --ansi                 Force ANSI styling in --render output\n\
      \x20     --plain                Force plain text in --render output\n\
+     \x20     --width <COLS>         Set render output width\n\
      \x20     --theme <NAME>         Set color theme preset or custom config theme\n\
      \x20 -e, --editor <NAME>        Set external editor (nano|vim|code|subl|emacs)\n\
      \x20     --picker               Open the file browser picker\n\
@@ -72,6 +74,16 @@ pub(crate) fn parse_cli(args: &[String]) -> Result<CliOptions> {
             "--render" => options.render = true,
             "--ansi" => options.ansi = true,
             "--plain" => options.plain = true,
+            "--width" => {
+                let Some(value) = iter.next() else {
+                    anyhow::bail!("Missing value for --width");
+                };
+                options.width = Some(parse_width(value)?);
+            }
+            _ if arg.starts_with("--width=") => {
+                let value = &arg["--width=".len()..];
+                options.width = Some(parse_width(value)?);
+            }
             "--update" => options.update = true,
             "--config" => options.config = true,
             "--debug-input" => options.debug_input = true,
@@ -109,6 +121,7 @@ pub(crate) fn parse_cli(args: &[String]) -> Result<CliOptions> {
             || options.render
             || options.ansi
             || options.plain
+            || options.width.is_some()
             || options.debug_input
             || options.config
             || options.file_arg.is_some()
@@ -125,6 +138,7 @@ pub(crate) fn parse_cli(args: &[String]) -> Result<CliOptions> {
             || options.render
             || options.ansi
             || options.plain
+            || options.width.is_some()
             || options.debug_input
             || options.update
             || options.file_arg.is_some()
@@ -160,8 +174,25 @@ pub(crate) fn parse_cli(args: &[String]) -> Result<CliOptions> {
     if options.plain && !options.render {
         anyhow::bail!("--plain requires --render");
     }
+    if options.width.is_some() && !options.render {
+        anyhow::bail!("--width requires --render");
+    }
 
     Ok(options)
+}
+
+fn parse_width(value: &str) -> Result<usize> {
+    let value = value.trim();
+    if value.is_empty() {
+        anyhow::bail!("Missing value for --width");
+    }
+    let width = value
+        .parse::<usize>()
+        .map_err(|_| anyhow::anyhow!("--width must be a positive integer"))?;
+    if width == 0 {
+        anyhow::bail!("--width must be a positive integer");
+    }
+    Ok(width)
 }
 
 fn parse_theme_name(name: &str) -> Result<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod cli;
 mod config;
 mod editor;
 mod markdown;
+mod one_shot;
 mod render;
 mod runtime;
 mod terminal;
@@ -18,7 +19,8 @@ mod update;
 
 use app::{App, AppConfig};
 use cli::{parse_cli, print_usage, print_version, CliOptions};
-use markdown::{hash_str, parse_markdown, read_file_state};
+use markdown::{hash_str, parse_markdown, parse_markdown_with_width, read_file_state};
+use one_shot::{terminal_render_width, write_lines, ColorMode};
 use runtime::run;
 use terminal::{finish_with_restore, TerminalSession};
 use theme::{
@@ -111,6 +113,9 @@ fn main() -> Result<()> {
     let CliOptions {
         picker,
         watch: watch_from_cli,
+        render,
+        ansi,
+        plain,
         debug_input,
         file_arg,
         theme: cli_theme,
@@ -163,6 +168,9 @@ fn main() -> Result<()> {
         (content, name, Some(path))
     } else {
         if io::stdin().is_terminal() {
+            if render {
+                bail!("--render requires a file path or stdin");
+            }
             let cwd = std::env::current_dir().context("Cannot read current directory")?;
             let label = cwd
                 .file_name()
@@ -213,6 +221,20 @@ fn main() -> Result<()> {
     let last_content_hash = hash_str(&src);
 
     let at = app_theme();
+    if render {
+        let mode = if ansi {
+            ColorMode::Ansi
+        } else if plain || !io::stdout().is_terminal() {
+            ColorMode::Plain
+        } else {
+            ColorMode::Ansi
+        };
+        let width = terminal_render_width();
+        let (lines, _) = parse_markdown_with_width(&src, &ss, &theme, width, &at.markdown);
+        let mut stdout = io::stdout().lock();
+        write_lines(&mut stdout, &lines, mode)?;
+        return Ok(());
+    }
     let (lines, toc) = parse_markdown(&src, &ss, &theme, &at.markdown);
     let mut app = App::new_with_source(
         lines,

--- a/src/main.rs
+++ b/src/main.rs
@@ -225,9 +225,7 @@ fn main() -> Result<()> {
         if let Some(warning) = config_warning.as_deref() {
             eprintln!("leaf: {warning}");
         }
-        let mode = if ansi {
-            ColorMode::Ansi
-        } else if plain || !io::stdout().is_terminal() {
+        let mode = if plain || (!ansi && !io::stdout().is_terminal()) {
             ColorMode::Plain
         } else {
             ColorMode::Ansi

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,6 +222,9 @@ fn main() -> Result<()> {
 
     let at = app_theme();
     if render {
+        if let Some(warning) = config_warning.as_deref() {
+            eprintln!("leaf: {warning}");
+        }
         let mode = if ansi {
             ColorMode::Ansi
         } else if plain || !io::stdout().is_terminal() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ mod update;
 use app::{App, AppConfig};
 use cli::{parse_cli, print_usage, print_version, CliOptions};
 use markdown::{hash_str, parse_markdown, parse_markdown_with_width, read_file_state};
-use one_shot::{terminal_render_width, write_lines, ColorMode};
+use one_shot::{render_width, write_lines, ColorMode};
 use runtime::run;
 use terminal::{finish_with_restore, TerminalSession};
 use theme::{
@@ -116,6 +116,7 @@ fn main() -> Result<()> {
         render,
         ansi,
         plain,
+        width,
         debug_input,
         file_arg,
         theme: cli_theme,
@@ -225,12 +226,13 @@ fn main() -> Result<()> {
         if let Some(warning) = config_warning.as_deref() {
             eprintln!("leaf: {warning}");
         }
-        let mode = if plain || (!ansi && !io::stdout().is_terminal()) {
+        let stdout_is_terminal = io::stdout().is_terminal();
+        let mode = if plain || (!ansi && !stdout_is_terminal) {
             ColorMode::Plain
         } else {
             ColorMode::Ansi
         };
-        let width = terminal_render_width();
+        let width = render_width(stdout_is_terminal, width);
         let (lines, _) = parse_markdown_with_width(&src, &ss, &theme, width, &at.markdown);
         let mut stdout = io::stdout().lock();
         write_lines(&mut stdout, &lines, mode)?;

--- a/src/one_shot.rs
+++ b/src/one_shot.rs
@@ -5,16 +5,24 @@ use ratatui::{
 };
 use std::io::Write;
 
+pub(crate) const DEFAULT_RENDER_WIDTH: usize = 80;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ColorMode {
     Ansi,
     Plain,
 }
 
-pub(crate) fn terminal_render_width() -> usize {
-    crossterm::terminal::size()
-        .map(|(width, _)| usize::from(width).max(1))
-        .unwrap_or(80)
+pub(crate) fn render_width(stdout_is_terminal: bool, width_override: Option<usize>) -> usize {
+    if let Some(width) = width_override {
+        return width;
+    }
+    if stdout_is_terminal {
+        return crossterm::terminal::size()
+            .map(|(width, _)| usize::from(width).max(1))
+            .unwrap_or(DEFAULT_RENDER_WIDTH);
+    }
+    DEFAULT_RENDER_WIDTH
 }
 
 pub(crate) fn write_lines<W: Write>(

--- a/src/one_shot.rs
+++ b/src/one_shot.rs
@@ -1,0 +1,119 @@
+use anyhow::Result;
+use ratatui::{
+    style::{Color, Modifier, Style},
+    text::Line,
+};
+use std::io::Write;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ColorMode {
+    Ansi,
+    Plain,
+}
+
+pub(crate) fn terminal_render_width() -> usize {
+    crossterm::terminal::size()
+        .map(|(width, _)| usize::from(width).max(1))
+        .unwrap_or(80)
+}
+
+pub(crate) fn write_lines<W: Write>(
+    writer: &mut W,
+    lines: &[Line<'_>],
+    mode: ColorMode,
+) -> Result<()> {
+    let lines = trim_trailing_empty_lines(lines);
+    for line in lines {
+        for span in &line.spans {
+            match mode {
+                ColorMode::Ansi => {
+                    write_style(writer, span.style)?;
+                    write!(writer, "{}", span.content)?;
+                    write!(writer, "\x1b[0m")?;
+                }
+                ColorMode::Plain => write!(writer, "{}", span.content)?,
+            }
+        }
+        writeln!(writer)?;
+    }
+    Ok(())
+}
+
+fn trim_trailing_empty_lines<'a>(lines: &'a [Line<'a>]) -> &'a [Line<'a>] {
+    let end = lines
+        .iter()
+        .rposition(|line| line.spans.iter().any(|span| !span.content.is_empty()))
+        .map_or(0, |index| index + 1);
+    &lines[..end]
+}
+
+fn write_style<W: Write>(writer: &mut W, style: Style) -> Result<()> {
+    let mut codes = Vec::new();
+
+    if let Some(color) = style.fg {
+        push_color_code(&mut codes, color, false);
+    }
+    if let Some(color) = style.bg {
+        push_color_code(&mut codes, color, true);
+    }
+
+    let modifiers = style.add_modifier;
+    if modifiers.contains(Modifier::BOLD) {
+        codes.push("1".to_string());
+    }
+    if modifiers.contains(Modifier::DIM) {
+        codes.push("2".to_string());
+    }
+    if modifiers.contains(Modifier::ITALIC) {
+        codes.push("3".to_string());
+    }
+    if modifiers.contains(Modifier::UNDERLINED) {
+        codes.push("4".to_string());
+    }
+    if modifiers.contains(Modifier::CROSSED_OUT) {
+        codes.push("9".to_string());
+    }
+
+    if !codes.is_empty() {
+        write!(writer, "\x1b[{}m", codes.join(";"))?;
+    }
+    Ok(())
+}
+
+fn push_color_code(codes: &mut Vec<String>, color: Color, background: bool) {
+    match color {
+        Color::Reset => {}
+        Color::Black => codes.push(base_code(background, 30).to_string()),
+        Color::Red => codes.push(base_code(background, 31).to_string()),
+        Color::Green => codes.push(base_code(background, 32).to_string()),
+        Color::Yellow => codes.push(base_code(background, 33).to_string()),
+        Color::Blue => codes.push(base_code(background, 34).to_string()),
+        Color::Magenta => codes.push(base_code(background, 35).to_string()),
+        Color::Cyan => codes.push(base_code(background, 36).to_string()),
+        Color::Gray => codes.push(base_code(background, 37).to_string()),
+        Color::DarkGray => codes.push(base_code(background, 90).to_string()),
+        Color::LightRed => codes.push(base_code(background, 91).to_string()),
+        Color::LightGreen => codes.push(base_code(background, 92).to_string()),
+        Color::LightYellow => codes.push(base_code(background, 93).to_string()),
+        Color::LightBlue => codes.push(base_code(background, 94).to_string()),
+        Color::LightMagenta => codes.push(base_code(background, 95).to_string()),
+        Color::LightCyan => codes.push(base_code(background, 96).to_string()),
+        Color::White => codes.push(base_code(background, 97).to_string()),
+        Color::Indexed(index) => {
+            let prefix = if background { 48 } else { 38 };
+            codes.push(format!("{prefix};5;{index}"));
+        }
+        Color::Rgb(red, green, blue) => {
+            let prefix = if background { 48 } else { 38 };
+            codes.push(format!("{prefix};2;{red};{green};{blue}"));
+        }
+    }
+}
+
+fn base_code(background: bool, code: u8) -> u8 {
+    if background {
+        code + 10
+    } else {
+        code
+    }
+}

--- a/src/tests/app.rs
+++ b/src/tests/app.rs
@@ -183,6 +183,33 @@ fn parse_cli_accepts_render_with_plain() {
 }
 
 #[test]
+fn parse_cli_accepts_render_with_width() {
+    let args = vec![
+        "leaf".to_string(),
+        "--render".to_string(),
+        "--width".to_string(),
+        "100".to_string(),
+    ];
+    let options = parse_cli(&args).unwrap();
+
+    assert!(options.render);
+    assert_eq!(options.width, Some(100));
+}
+
+#[test]
+fn parse_cli_accepts_render_with_equals_width() {
+    let args = vec![
+        "leaf".to_string(),
+        "--render".to_string(),
+        "--width=120".to_string(),
+    ];
+    let options = parse_cli(&args).unwrap();
+
+    assert!(options.render);
+    assert_eq!(options.width, Some(120));
+}
+
+#[test]
 fn parse_cli_rejects_render_with_watch() {
     let args = vec![
         "leaf".to_string(),
@@ -239,6 +266,44 @@ fn parse_cli_rejects_ansi_with_plain() {
     assert!(err
         .to_string()
         .contains("--ansi and --plain cannot be combined"));
+}
+
+#[test]
+fn parse_cli_rejects_width_without_render() {
+    let args = vec!["leaf".to_string(), "--width".to_string(), "100".to_string()];
+
+    let err = parse_cli(&args).unwrap_err();
+    assert!(err.to_string().contains("--width requires --render"));
+}
+
+#[test]
+fn parse_cli_rejects_zero_width() {
+    let args = vec![
+        "leaf".to_string(),
+        "--render".to_string(),
+        "--width".to_string(),
+        "0".to_string(),
+    ];
+
+    let err = parse_cli(&args).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("--width must be a positive integer"));
+}
+
+#[test]
+fn parse_cli_rejects_invalid_width() {
+    let args = vec![
+        "leaf".to_string(),
+        "--render".to_string(),
+        "--width".to_string(),
+        "wide".to_string(),
+    ];
+
+    let err = parse_cli(&args).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("--width must be a positive integer"));
 }
 
 #[test]

--- a/src/tests/app.rs
+++ b/src/tests/app.rs
@@ -121,6 +121,127 @@ fn parse_cli_accepts_picker_with_watch() {
 }
 
 #[test]
+fn parse_cli_accepts_render_with_file() {
+    let args = vec![
+        "leaf".to_string(),
+        "--render".to_string(),
+        "README.md".to_string(),
+    ];
+    let options = parse_cli(&args).unwrap();
+
+    assert!(options.render);
+    assert_eq!(options.file_arg.as_deref(), Some("README.md"));
+}
+
+#[test]
+fn parse_cli_accepts_render_on_its_own() {
+    let args = vec!["leaf".to_string(), "--render".to_string()];
+    let options = parse_cli(&args).unwrap();
+
+    assert!(options.render);
+    assert_eq!(options.file_arg, None);
+}
+
+#[test]
+fn parse_cli_accepts_render_with_theme() {
+    let args = vec![
+        "leaf".to_string(),
+        "--render".to_string(),
+        "--theme".to_string(),
+        "ocean".to_string(),
+    ];
+    let options = parse_cli(&args).unwrap();
+
+    assert!(options.render);
+    assert_eq!(options.theme.as_deref(), Some("ocean"));
+}
+
+#[test]
+fn parse_cli_accepts_render_with_ansi() {
+    let args = vec![
+        "leaf".to_string(),
+        "--render".to_string(),
+        "--ansi".to_string(),
+    ];
+    let options = parse_cli(&args).unwrap();
+
+    assert!(options.render);
+    assert!(options.ansi);
+}
+
+#[test]
+fn parse_cli_accepts_render_with_plain() {
+    let args = vec![
+        "leaf".to_string(),
+        "--render".to_string(),
+        "--plain".to_string(),
+    ];
+    let options = parse_cli(&args).unwrap();
+
+    assert!(options.render);
+    assert!(options.plain);
+}
+
+#[test]
+fn parse_cli_rejects_render_with_watch() {
+    let args = vec![
+        "leaf".to_string(),
+        "--render".to_string(),
+        "--watch".to_string(),
+    ];
+
+    let err = parse_cli(&args).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("--render cannot be combined with --watch"));
+}
+
+#[test]
+fn parse_cli_rejects_render_with_picker() {
+    let args = vec![
+        "leaf".to_string(),
+        "--render".to_string(),
+        "--picker".to_string(),
+    ];
+
+    let err = parse_cli(&args).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("--render cannot be combined with --picker"));
+}
+
+#[test]
+fn parse_cli_rejects_ansi_without_render() {
+    let args = vec!["leaf".to_string(), "--ansi".to_string()];
+
+    let err = parse_cli(&args).unwrap_err();
+    assert!(err.to_string().contains("--ansi requires --render"));
+}
+
+#[test]
+fn parse_cli_rejects_plain_without_render() {
+    let args = vec!["leaf".to_string(), "--plain".to_string()];
+
+    let err = parse_cli(&args).unwrap_err();
+    assert!(err.to_string().contains("--plain requires --render"));
+}
+
+#[test]
+fn parse_cli_rejects_ansi_with_plain() {
+    let args = vec![
+        "leaf".to_string(),
+        "--render".to_string(),
+        "--ansi".to_string(),
+        "--plain".to_string(),
+    ];
+
+    let err = parse_cli(&args).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("--ansi and --plain cannot be combined"));
+}
+
+#[test]
 fn parse_cli_accepts_custom_theme_names() {
     let args = vec![
         "leaf".to_string(),

--- a/src/tests/render.rs
+++ b/src/tests/render.rs
@@ -1,6 +1,6 @@
 use super::{find_symbol, render_buffer, test_assets, test_md_theme};
 use crate::markdown::parse_markdown;
-use crate::one_shot::{write_lines, ColorMode};
+use crate::one_shot::{render_width, write_lines, ColorMode, DEFAULT_RENDER_WIDTH};
 use crate::wrap_path_lines;
 use ratatui::{
     style::{Color, Modifier, Style},
@@ -177,4 +177,15 @@ fn one_shot_output_trims_trailing_empty_lines() {
     write_lines(&mut output, &lines, ColorMode::Plain).unwrap();
 
     assert_eq!(String::from_utf8(output).unwrap(), "hello\n");
+}
+
+#[test]
+fn one_shot_render_width_uses_override() {
+    assert_eq!(render_width(false, Some(100)), 100);
+    assert_eq!(render_width(true, Some(120)), 120);
+}
+
+#[test]
+fn one_shot_render_width_defaults_to_80_for_non_tty_stdout() {
+    assert_eq!(render_width(false, None), DEFAULT_RENDER_WIDTH);
 }

--- a/src/tests/render.rs
+++ b/src/tests/render.rs
@@ -1,7 +1,11 @@
 use super::{find_symbol, render_buffer, test_assets, test_md_theme};
 use crate::markdown::parse_markdown;
+use crate::one_shot::{write_lines, ColorMode};
 use crate::wrap_path_lines;
-use ratatui::style::Style;
+use ratatui::{
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+};
 
 #[test]
 fn code_block_box_renders_right_border_in_one_column() {
@@ -132,4 +136,45 @@ fn wrap_path_lines_one_char_over_wraps() {
     let path = "x".repeat(74 - label.len() + 1);
     let lines = wrap_path_lines(label, &path, 74, s, s);
     assert_eq!(lines.len(), 2);
+}
+
+#[test]
+fn one_shot_plain_output_writes_text_without_ansi() {
+    let lines = vec![Line::from(vec![
+        Span::raw("hello "),
+        Span::styled("world", Style::default().fg(Color::Red)),
+    ])];
+    let mut output = Vec::new();
+
+    write_lines(&mut output, &lines, ColorMode::Plain).unwrap();
+
+    assert_eq!(String::from_utf8(output).unwrap(), "hello world\n");
+}
+
+#[test]
+fn one_shot_ansi_output_writes_styles_and_resets() {
+    let lines = vec![Line::from(vec![Span::styled(
+        "hello",
+        Style::default()
+            .fg(Color::Rgb(1, 2, 3))
+            .add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+    )])];
+    let mut output = Vec::new();
+
+    write_lines(&mut output, &lines, ColorMode::Ansi).unwrap();
+
+    assert_eq!(
+        String::from_utf8(output).unwrap(),
+        "\x1b[38;2;1;2;3;1;4mhello\x1b[0m\n"
+    );
+}
+
+#[test]
+fn one_shot_output_trims_trailing_empty_lines() {
+    let lines = vec![Line::from("hello"), Line::from(""), Line::from("")];
+    let mut output = Vec::new();
+
+    write_lines(&mut output, &lines, ColorMode::Plain).unwrap();
+
+    assert_eq!(String::from_utf8(output).unwrap(), "hello\n");
 }


### PR DESCRIPTION
Closes #94

## Summary

- add `--render` for non-interactive Markdown rendering to stdout
- add render output controls for ANSI/plain text and explicit width
- document one-shot render usage and add focused CLI/serializer tests

## Testing

- `cargo fmt --all -- --check`
- `env -u LEAF_EDITOR -u VISUAL -u EDITOR cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`
- `cargo audit` (completed with existing allowed dependency warnings)
- `cargo build --target aarch64-unknown-linux-gnu`
- `target/aarch64-unknown-linux-gnu/debug/leaf --render --plain --width 60 README.md > /tmp/leaf-render-width-60.txt`
- `target/aarch64-unknown-linux-gnu/debug/leaf --render --plain README.md > /tmp/leaf-render-width-default.txt`