### PR TITLE
fix: redraw on terminal resize

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -590,9 +590,8 @@ pub(crate) fn run(
             .unwrap_or(false)
         {
             pending_resize = None;
-            if sync_render_width(terminal, app, ss, themes)? {
-                needs_redraw = true;
-            }
+            sync_render_width(terminal, app, ss, themes)?;
+            needs_redraw = true;
         }
 
         if app.is_watch_enabled() {


### PR DESCRIPTION
Closes #90

## What changed

- redraw the UI after a terminal resize, even if the content width stays the same

## Why it changed

Before this change, resizing only the terminal height could leave the screen stale because redraw happened only when width changed.

## How it was tested

- `env -u LEAF_EDITOR -u VISUAL -u EDITOR cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`
- ran `cargo run -- TESTING.md`
- resized the terminal taller and shorter and checked that the UI updated correctly