### PR TITLE
docs: Instructions for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ curl -fsSL https://raw.githubusercontent.com/RivoLink/leaf/main/scripts/install.
 irm https://raw.githubusercontent.com/RivoLink/leaf/main/scripts/install.ps1 | iex
 ```
 
+**Homebrew:**
+
+```bash
+brew install leaf-md
+```
+
 **npm:**
 
 ```bash


### PR DESCRIPTION
Leaf is now [available](https://github.com/chrisfinazzo/homebrew-core/commit/b71f509a4a7eb17d3e39b53c4bb55859e62f92f9) to install via [Homebrew](https://brew.sh/).

Is the website source available to update the installation methods? 🤔