### PR TITLE
Docs/clarify text selection modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,9 @@ See [`gruvbox.toml`](gruvbox.toml) for a complete example with all available col
 | `Ctrl+F` / `/` | Find | `Ctrl+E` | Open in editor |
 | `n` / `N` | Next / prev match | `Ctrl+Click` | Open link |
 | `r` | Force reload (watch mode) | `Dbl-Click` | Copy link |
-| `q` | Quit | `Shift+Sel` | Select text |
+| `q` | Quit | `Shift/Alt+drag` | Select text |
+
+> **Text selection** depends on your terminal: **Shift+drag** on most terminals (Linux, Alacritty, Kitty, Windows Terminal), **Option/Alt+drag** on iTerm2. macOS Terminal.app does not support bypassing mouse capture — text selection is unavailable there.
 
 ## Features
 

--- a/src/render/popup.rs
+++ b/src/render/popup.rs
@@ -118,7 +118,7 @@ pub(super) fn render_help_popup(f: &mut Frame, _app: &App) {
             Span::styled("g/G        ", key_style),
             Span::styled("top/bottom", text_style),
             Span::raw("        "),
-            Span::styled("shift+slct ", key_style),
+            Span::styled("shift/alt  ", key_style),
             Span::styled("select text", text_style),
         ]),
         Line::from(vec![


### PR DESCRIPTION
Corrects the text-selection modifier hint: `Shift` only works on most Linux terminals; iTerm2 requires `Option/Alt`; macOS `Terminal.app` has no bypass at all. Updates the README keybindings table and in-app help popup label accordingly, and adds a note explaining the terminal-dependency. No testing was done for this doc-only change.