### PR TITLE
fix: TOC - allow any heading level as root

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     markdown::{
         build_searchable_lines,
-        toc::{should_hide_single_h1, should_promote_h2_when_no_h1, toc_display_level, TocEntry},
+        toc::{toc_display_level, toc_promotion, TocEntry},
         LinkSpan,
     },
     render::{build_status_bar, build_toc_line_with_index, toc_header_line},
@@ -404,8 +404,8 @@ impl App {
     }
 
     pub(crate) fn active_toc_index(&self) -> Option<usize> {
-        let hide_single_h1 = should_hide_single_h1(&self.toc);
-        let is_visible = |entry: &&TocEntry| !(hide_single_h1 && entry.level == 1);
+        let (shift, hide_root) = toc_promotion(&self.toc);
+        let is_visible = |entry: &&TocEntry| !(hide_root && entry.level <= shift);
 
         let mut first_visible = None;
         let mut active = None;
@@ -463,8 +463,7 @@ impl App {
     }
 
     pub(crate) fn refresh_toc_cache(&mut self) {
-        let hide_single_h1 = should_hide_single_h1(&self.toc);
-        let promote_h2_root = should_promote_h2_when_no_h1(&self.toc);
+        let (shift, hide_root) = toc_promotion(&self.toc);
         let active_idx = self.active_toc_index();
         if self.toc_active_idx == active_idx && !self.toc_display_lines.is_empty() {
             return;
@@ -476,9 +475,9 @@ impl App {
             .toc
             .iter()
             .enumerate()
-            .filter(|(_, entry)| !(hide_single_h1 && entry.level == 1))
+            .filter(|(_, entry)| !(hide_root && entry.level <= shift))
             .map(|(idx, entry)| {
-                let display_level = toc_display_level(entry.level, hide_single_h1, promote_h2_root);
+                let display_level = toc_display_level(entry.level, shift, hide_root);
                 let line = build_toc_line_with_index(
                     entry,
                     display_level,

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -1,7 +1,5 @@
 use super::App;
-use crate::markdown::toc::{
-    should_hide_single_h1, should_promote_h2_when_no_h1, toc_display_level,
-};
+use crate::markdown::toc::{toc_display_level, toc_promotion};
 
 pub(super) enum CycleDirection {
     Forward,
@@ -70,17 +68,16 @@ impl App {
     }
 
     fn toc_group_for_numkey(&self, key: u8) -> Vec<usize> {
-        let hide_single_h1 = should_hide_single_h1(&self.toc);
-        let promote_h2_root = should_promote_h2_when_no_h1(&self.toc);
+        let (shift, hide_root) = toc_promotion(&self.toc);
         let mut group = Vec::new();
         let mut top_level_index = 0u8;
         let mut collecting = false;
 
         for (idx, entry) in self.toc.iter().enumerate() {
-            if hide_single_h1 && entry.level == 1 {
+            if hide_root && entry.level <= shift {
                 continue;
             }
-            let display_level = toc_display_level(entry.level, hide_single_h1, promote_h2_root);
+            let display_level = toc_display_level(entry.level, shift, hide_root);
             if display_level == 1 {
                 if collecting {
                     break;

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,9 +40,7 @@ pub(crate) use editor::{
     try_new_tab_command, EditorKind, TerminalEmulator,
 };
 #[cfg(test)]
-pub(crate) use markdown::toc::{
-    normalize_toc, should_hide_single_h1, should_promote_h2_when_no_h1, toc_display_level, TocEntry,
-};
+pub(crate) use markdown::toc::{normalize_toc, toc_display_level, toc_promotion, TocEntry};
 #[cfg(test)]
 pub(crate) use markdown::{display_width, line_plain_text};
 #[cfg(test)]

--- a/src/markdown/toc.rs
+++ b/src/markdown/toc.rs
@@ -5,33 +5,51 @@ pub(crate) struct TocEntry {
     pub(crate) line: usize,
 }
 
-pub(crate) fn should_hide_single_h1(toc: &[TocEntry]) -> bool {
-    let h1_count = toc.iter().filter(|entry| entry.level == 1).count();
-    let has_h2 = toc.iter().any(|entry| entry.level == 2);
-    h1_count == 1 && has_h2
-}
+/// Computes how many levels to shift headings down so that the document's
+/// top-level headings appear as root (display level 1).
+///
+/// Returns `(shift, hide_root)` where:
+/// - `shift` is the number of levels to subtract from every heading
+/// - `hide_root` indicates the single top-level heading should be hidden
+///   (analogous to the old "hide single h1" behaviour)
+pub(crate) fn toc_promotion(toc: &[TocEntry]) -> (u8, bool) {
+    let Some(min_level) = toc.iter().map(|e| e.level).min() else {
+        return (0, false);
+    };
 
-pub(crate) fn should_promote_h2_when_no_h1(toc: &[TocEntry]) -> bool {
-    !toc.iter().any(|entry| entry.level == 1) && toc.iter().any(|entry| entry.level == 2)
-}
+    let min_count = toc.iter().filter(|e| e.level == min_level).count();
+    let has_deeper = toc.iter().any(|e| e.level > min_level);
 
-pub(crate) fn toc_display_level(level: u8, hide_single_h1: bool, promote_h2_root: bool) -> u8 {
-    if hide_single_h1 || promote_h2_root {
-        match level {
-            2 => 1,
-            3 => 2,
-            _ => level,
-        }
+    // Only hide the single root heading when it is an H1; for other
+    // minimum levels we simply shift without hiding.
+    if min_level == 1 && min_count == 1 && has_deeper {
+        let next_min = toc
+            .iter()
+            .filter(|e| e.level > min_level)
+            .map(|e| e.level)
+            .min()
+            .unwrap_or(min_level);
+        (next_min - 1, true)
     } else {
-        level
+        (min_level - 1, false)
     }
+}
+
+pub(crate) fn toc_display_level(level: u8, shift: u8, hide_root: bool) -> u8 {
+    if hide_root && level <= shift {
+        // This entry is the hidden single root; callers filter it out,
+        // but if it reaches here return 0 as a sentinel.
+        return 0;
+    }
+    level.saturating_sub(shift)
 }
 
 pub(crate) fn normalize_toc(mut toc: Vec<TocEntry>) -> Vec<TocEntry> {
-    if should_hide_single_h1(&toc) || should_promote_h2_when_no_h1(&toc) {
-        toc.retain(|entry| matches!(entry.level, 1..=3));
-    } else {
-        toc.retain(|entry| matches!(entry.level, 1..=2));
-    }
+    let Some(min_level) = toc.iter().map(|e| e.level).min() else {
+        return toc;
+    };
+    // Keep at most 3 heading levels starting from the document minimum.
+    let max_raw = min_level + 2;
+    toc.retain(|entry| entry.level <= max_raw);
     toc
 }

--- a/src/tests/toc.rs
+++ b/src/tests/toc.rs
@@ -110,9 +110,11 @@ fn toc_hides_single_h1_when_h2_entries_exist() {
         },
     ];
 
-    assert!(should_hide_single_h1(&toc));
-    assert_eq!(toc_display_level(2, true, false), 1);
-    assert_eq!(toc_display_level(3, true, false), 2);
+    let (shift, hide_root) = toc_promotion(&toc);
+    assert!(hide_root);
+    assert_eq!(shift, 1);
+    assert_eq!(toc_display_level(2, shift, hide_root), 1);
+    assert_eq!(toc_display_level(3, shift, hide_root), 2);
 }
 
 #[test]
@@ -123,7 +125,8 @@ fn toc_keeps_single_h1_when_no_h2_entries_exist() {
         line: 0,
     }];
 
-    assert!(!should_hide_single_h1(&toc));
+    let (_shift, hide_root) = toc_promotion(&toc);
+    assert!(!hide_root);
 }
 
 #[test]
@@ -141,11 +144,63 @@ fn toc_promotes_h2_when_document_has_no_h1() {
         },
     ];
 
-    assert!(should_promote_h2_when_no_h1(&toc));
-    assert_eq!(toc_display_level(2, false, true), 1);
-    assert_eq!(toc_display_level(3, false, true), 2);
+    let (shift, hide_root) = toc_promotion(&toc);
+    assert!(!hide_root);
+    assert_eq!(shift, 1);
+    assert_eq!(toc_display_level(2, shift, hide_root), 1);
+    assert_eq!(toc_display_level(3, shift, hide_root), 2);
     let normalized = normalize_toc(toc);
     assert_eq!(normalized.len(), 2);
     assert_eq!(normalized[0].level, 2);
     assert_eq!(normalized[1].level, 3);
+}
+
+#[test]
+fn toc_promotes_h3_when_document_has_no_h1_or_h2() {
+    let toc = vec![
+        TocEntry {
+            level: 3,
+            title: "Section A".to_string(),
+            line: 0,
+        },
+        TocEntry {
+            level: 4,
+            title: "Subsection".to_string(),
+            line: 5,
+        },
+    ];
+
+    let (shift, hide_root) = toc_promotion(&toc);
+    assert!(!hide_root);
+    assert_eq!(shift, 2);
+    assert_eq!(toc_display_level(3, shift, hide_root), 1);
+    assert_eq!(toc_display_level(4, shift, hide_root), 2);
+}
+
+#[test]
+fn toc_promotes_single_h3_to_root_without_hiding() {
+    let toc = vec![
+        TocEntry {
+            level: 3,
+            title: "Only H3".to_string(),
+            line: 0,
+        },
+        TocEntry {
+            level: 4,
+            title: "Child".to_string(),
+            line: 5,
+        },
+        TocEntry {
+            level: 5,
+            title: "Grandchild".to_string(),
+            line: 10,
+        },
+    ];
+
+    let (shift, hide_root) = toc_promotion(&toc);
+    assert!(!hide_root);
+    assert_eq!(shift, 2);
+    assert_eq!(toc_display_level(3, shift, hide_root), 1);
+    assert_eq!(toc_display_level(4, shift, hide_root), 2);
+    assert_eq!(toc_display_level(5, shift, hide_root), 3);
 }


### PR DESCRIPTION
partially fixes #179

The original `hide_single_h1` had unintentional behavior: it would display the single H1 in the TOC but other headings would be missing. The new `hide_root` boolean hides the actual H1, and preserves the other headings in the TOC.

Work-In-Progress
-
There should be some better handling for setting `hide_root` in `toc_promotion()`. Current behavior:
- Single H1: promote next largest heading to root (numbered headers), no bullets for non-root headers
- No H1, yes H2: all H2 are promoted (numbered), H3 and H4 as bullets, H5 not visible
- No H1, no H2: promote next largest heading to root (numbered), next 2 headers as bullets, 3rd level not visible

This is a step up from the main branch but still needs refinement. This could be handled recursively through to the lowest level header (H6).