### PR TITLE
fix: toc generalize heading levels

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     markdown::{
         build_searchable_lines,
-        toc::{should_hide_single_h1, should_promote_h2_when_no_h1, toc_display_level, TocEntry},
+        toc::{toc_levels, TocEntry},
         LinkSpan,
     },
     render::{build_status_bar, build_toc_line_with_index, toc_header_line},
@@ -404,8 +404,12 @@ impl App {
     }
 
     pub(crate) fn active_toc_index(&self) -> Option<usize> {
-        let hide_single_h1 = should_hide_single_h1(&self.toc);
-        let is_visible = |entry: &&TocEntry| !(hide_single_h1 && entry.level == 1);
+        let levels = toc_levels(&self.toc);
+        let is_visible = |entry: &&TocEntry| {
+            levels
+                .as_ref()
+                .is_some_and(|l| l.display_level(entry.level).is_some())
+        };
 
         let mut first_visible = None;
         let mut active = None;
@@ -463,8 +467,7 @@ impl App {
     }
 
     pub(crate) fn refresh_toc_cache(&mut self) {
-        let hide_single_h1 = should_hide_single_h1(&self.toc);
-        let promote_h2_root = should_promote_h2_when_no_h1(&self.toc);
+        let levels = toc_levels(&self.toc);
         let active_idx = self.active_toc_index();
         if self.toc_active_idx == active_idx && !self.toc_display_lines.is_empty() {
             return;
@@ -476,9 +479,8 @@ impl App {
             .toc
             .iter()
             .enumerate()
-            .filter(|(_, entry)| !(hide_single_h1 && entry.level == 1))
-            .map(|(idx, entry)| {
-                let display_level = toc_display_level(entry.level, hide_single_h1, promote_h2_root);
+            .filter_map(|(idx, entry)| {
+                let display_level = levels.as_ref()?.display_level(entry.level)?;
                 let line = build_toc_line_with_index(
                     entry,
                     display_level,
@@ -488,7 +490,7 @@ impl App {
                 if display_level == 1 {
                     top_level_index += 1;
                 }
-                line
+                Some(line)
             })
             .collect();
     }

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -1,7 +1,5 @@
 use super::App;
-use crate::markdown::toc::{
-    should_hide_single_h1, should_promote_h2_when_no_h1, toc_display_level,
-};
+use crate::markdown::toc::toc_levels;
 
 pub(super) enum CycleDirection {
     Forward,
@@ -70,17 +68,16 @@ impl App {
     }
 
     fn toc_group_for_numkey(&self, key: u8) -> Vec<usize> {
-        let hide_single_h1 = should_hide_single_h1(&self.toc);
-        let promote_h2_root = should_promote_h2_when_no_h1(&self.toc);
+        let levels = toc_levels(&self.toc);
         let mut group = Vec::new();
         let mut top_level_index = 0u8;
         let mut collecting = false;
 
         for (idx, entry) in self.toc.iter().enumerate() {
-            if hide_single_h1 && entry.level == 1 {
+            let Some(display_level) = levels.as_ref().and_then(|l| l.display_level(entry.level))
+            else {
                 continue;
-            }
-            let display_level = toc_display_level(entry.level, hide_single_h1, promote_h2_root);
+            };
             if display_level == 1 {
                 if collecting {
                     break;

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,9 +40,7 @@ pub(crate) use editor::{
     try_new_tab_command, EditorKind, TerminalEmulator,
 };
 #[cfg(test)]
-pub(crate) use markdown::toc::{
-    normalize_toc, should_hide_single_h1, should_promote_h2_when_no_h1, toc_display_level, TocEntry,
-};
+pub(crate) use markdown::toc::{normalize_toc, toc_levels, TocEntry};
 #[cfg(test)]
 pub(crate) use markdown::{display_width, line_plain_text};
 #[cfg(test)]

--- a/src/markdown/toc.rs
+++ b/src/markdown/toc.rs
@@ -5,33 +5,50 @@ pub(crate) struct TocEntry {
     pub(crate) line: usize,
 }
 
-pub(crate) fn should_hide_single_h1(toc: &[TocEntry]) -> bool {
-    let h1_count = toc.iter().filter(|entry| entry.level == 1).count();
-    let has_h2 = toc.iter().any(|entry| entry.level == 2);
-    h1_count == 1 && has_h2
+pub(crate) struct TocLevels {
+    pub(crate) root: u8,
+    pub(crate) sub: Option<u8>,
 }
 
-pub(crate) fn should_promote_h2_when_no_h1(toc: &[TocEntry]) -> bool {
-    !toc.iter().any(|entry| entry.level == 1) && toc.iter().any(|entry| entry.level == 2)
-}
-
-pub(crate) fn toc_display_level(level: u8, hide_single_h1: bool, promote_h2_root: bool) -> u8 {
-    if hide_single_h1 || promote_h2_root {
-        match level {
-            2 => 1,
-            3 => 2,
-            _ => level,
+impl TocLevels {
+    pub(crate) fn display_level(&self, level: u8) -> Option<u8> {
+        if level == self.root {
+            Some(1)
+        } else if Some(level) == self.sub {
+            Some(2)
+        } else {
+            None
         }
-    } else {
-        level
     }
+}
+
+fn distinct_levels(toc: &[TocEntry]) -> Vec<u8> {
+    let mut levels: Vec<u8> = toc.iter().map(|e| e.level).collect();
+    levels.sort_unstable();
+    levels.dedup();
+    levels
+}
+
+pub(crate) fn toc_levels(toc: &[TocEntry]) -> Option<TocLevels> {
+    let levels = distinct_levels(toc);
+    let &top = levels.first()?;
+    let top_unique = toc.iter().filter(|e| e.level == top).count() == 1;
+    let root_idx = if top_unique && levels.len() >= 2 {
+        1
+    } else {
+        0
+    };
+    Some(TocLevels {
+        root: levels[root_idx],
+        sub: levels.get(root_idx + 1).copied(),
+    })
 }
 
 pub(crate) fn normalize_toc(mut toc: Vec<TocEntry>) -> Vec<TocEntry> {
-    if should_hide_single_h1(&toc) || should_promote_h2_when_no_h1(&toc) {
-        toc.retain(|entry| matches!(entry.level, 1..=3));
-    } else {
-        toc.retain(|entry| matches!(entry.level, 1..=2));
-    }
+    let levels = distinct_levels(&toc);
+    let Some(&max_keep) = levels.get(2).or_else(|| levels.last()) else {
+        return toc;
+    };
+    toc.retain(|entry| entry.level <= max_keep);
     toc
 }

--- a/src/tests/toc.rs
+++ b/src/tests/toc.rs
@@ -96,56 +96,112 @@ fn frontmatter_is_ignored_in_toc() {
 }
 
 #[test]
-fn toc_hides_single_h1_when_h2_entries_exist() {
-    let toc = vec![
-        TocEntry {
-            level: 1,
-            title: "Doc Title".to_string(),
-            line: 0,
-        },
-        TocEntry {
-            level: 2,
-            title: "Install".to_string(),
-            line: 10,
-        },
-    ];
-
-    assert!(should_hide_single_h1(&toc));
-    assert_eq!(toc_display_level(2, true, false), 1);
-    assert_eq!(toc_display_level(3, true, false), 2);
+fn toc_hides_unique_top_and_promotes_when_shallow() {
+    let toc = toc(&[(1, 0), (2, 10), (2, 20)]);
+    let levels = toc_levels(&toc).unwrap();
+    assert_eq!(levels.root, 2);
+    assert_eq!(levels.sub, None);
+    assert_eq!(levels.display_level(1), None);
+    assert_eq!(levels.display_level(2), Some(1));
 }
 
 #[test]
-fn toc_keeps_single_h1_when_no_h2_entries_exist() {
-    let toc = vec![TocEntry {
-        level: 1,
-        title: "Doc Title".to_string(),
-        line: 0,
-    }];
-
-    assert!(!should_hide_single_h1(&toc));
+fn toc_hides_unique_top_and_shows_two_paliers() {
+    let toc = toc(&[(1, 0), (2, 10), (3, 15)]);
+    let levels = toc_levels(&toc).unwrap();
+    assert_eq!(levels.root, 2);
+    assert_eq!(levels.sub, Some(3));
+    assert_eq!(levels.display_level(1), None);
+    assert_eq!(levels.display_level(2), Some(1));
+    assert_eq!(levels.display_level(3), Some(2));
 }
 
 #[test]
-fn toc_promotes_h2_when_document_has_no_h1() {
-    let toc = vec![
-        TocEntry {
-            level: 2,
-            title: "Build & install".to_string(),
-            line: 0,
-        },
-        TocEntry {
-            level: 3,
-            title: "Android".to_string(),
-            line: 4,
-        },
-    ];
+fn toc_keeps_single_heading_as_root() {
+    let toc = toc(&[(1, 0)]);
+    let levels = toc_levels(&toc).unwrap();
+    assert_eq!(levels.root, 1);
+    assert_eq!(levels.sub, None);
+    assert_eq!(levels.display_level(1), Some(1));
+}
 
-    assert!(should_promote_h2_when_no_h1(&toc));
-    assert_eq!(toc_display_level(2, false, true), 1);
-    assert_eq!(toc_display_level(3, false, true), 2);
+#[test]
+fn toc_keeps_non_unique_top_as_root() {
+    let toc = toc(&[(2, 0), (2, 10), (3, 14)]);
+    let levels = toc_levels(&toc).unwrap();
+    assert_eq!(levels.root, 2);
+    assert_eq!(levels.sub, Some(3));
+}
+
+#[test]
+fn toc_promotes_unique_deep_root() {
+    let toc = toc(&[(3, 0), (4, 5), (5, 10)]);
+    let levels = toc_levels(&toc).unwrap();
+    assert_eq!(levels.root, 4);
+    assert_eq!(levels.sub, Some(5));
+    assert_eq!(levels.display_level(3), None);
+    assert_eq!(levels.display_level(4), Some(1));
+    assert_eq!(levels.display_level(5), Some(2));
+}
+
+#[test]
+fn toc_deep_non_unique_top_is_root() {
+    let toc = toc(&[(3, 0), (3, 10), (4, 14)]);
+    let levels = toc_levels(&toc).unwrap();
+    assert_eq!(levels.root, 3);
+    assert_eq!(levels.sub, Some(4));
+}
+
+#[test]
+fn toc_promotion_is_not_recursive() {
+    let toc = toc(&[(1, 0), (2, 5), (3, 8), (3, 12)]);
+    let levels = toc_levels(&toc).unwrap();
+    assert_eq!(levels.root, 2);
+    assert_eq!(levels.sub, Some(3));
+    assert_eq!(levels.display_level(1), None);
+    assert_eq!(levels.display_level(2), Some(1));
+    assert_eq!(levels.display_level(3), Some(2));
+}
+
+#[test]
+fn toc_ignores_level_gaps_two_paliers() {
+    let toc = toc(&[(1, 0), (3, 5), (3, 10)]);
+    let levels = toc_levels(&toc).unwrap();
+    assert_eq!(levels.root, 3);
+    assert_eq!(levels.sub, None);
+    assert_eq!(levels.display_level(1), None);
+    assert_eq!(levels.display_level(3), Some(1));
+}
+
+#[test]
+fn toc_ignores_level_gaps_three_paliers() {
+    let toc = toc(&[(1, 0), (2, 5), (2, 9), (4, 12)]);
+    let levels = toc_levels(&toc).unwrap();
+    assert_eq!(levels.root, 2);
+    assert_eq!(levels.sub, Some(4));
+    assert_eq!(levels.display_level(2), Some(1));
+    assert_eq!(levels.display_level(4), Some(2));
+}
+
+#[test]
+fn toc_sub_is_next_present_palier() {
+    let toc = toc(&[(2, 0), (2, 5), (4, 9)]);
+    let levels = toc_levels(&toc).unwrap();
+    assert_eq!(levels.root, 2);
+    assert_eq!(levels.sub, Some(4));
+}
+
+#[test]
+fn toc_levels_empty_returns_none() {
+    assert!(toc_levels(&[]).is_none());
+}
+
+#[test]
+fn normalize_keeps_top_three_paliers() {
+    let toc = toc(&[(2, 0), (3, 5), (4, 10), (5, 15)]);
     let normalized = normalize_toc(toc);
-    assert_eq!(normalized.len(), 2);
-    assert_eq!(normalized[0].level, 2);
-    assert_eq!(normalized[1].level, 3);
+    assert_eq!(
+        normalized.iter().map(|e| e.level).collect::<Vec<_>>(),
+        vec![2, 3, 4]
+    );
 }


### PR DESCRIPTION
# TOC behavior : heading levels

The TOC shows at most 2 paliers (distinct heading levels actually present, gaps are ignored).

A unique top palier is treated as a document title and hidden, the next 1–2 present paliers
are shown.

Root entries are numbered (`01`, `02`, …), navigable with keys `1`-`9`, sub-level entries are bullets (`•`).

| Document (paliers present) | Root (numbered) | Sub-level (bullet) | Hidden |
|---|---|---|---|
| H1 unique + H2×n | H2 | - | H1 |
| H1 unique + H2 + H3 | H2 | H3 | H1 |
| H2×n + H3 (no H1) | H2 | H3 | - |
| H3×n + H4 (issue #179) | H3 | H4 | -|
| H3 unique + H4 + H5 | H4 | H5 | H3 |
| H1 unique + H3 (H2 skipped) | H3 | - | H1 |
| H1 unique + H2 + H4 (H3 skipped) | H2 | H4 | H1 |
| H1 unique + H2 unique + H3×n | H2 | H3 | H1 |
| H2×n + H4 (H3 skipped) | H2 | H4 | - |
| single heading | that heading | - | -|
| no headings | - | -| (`t` does nothing) |
