### PR TITLE
feat: image preview via terminal graphics protocols

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +114,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bincode"
@@ -138,9 +157,21 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -158,10 +189,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -241,6 +298,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,19 +351,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
  "filedescriptor",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -478,6 +572,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +651,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-channel"
@@ -652,6 +767,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +790,17 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -865,6 +1001,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "icy_sixel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85518b9086bf01117761b90e7691c0ef3236fa8adfb1fb44dd248fe5f87215d5"
+dependencies = [
+ "quantette",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,6 +1041,34 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -1009,9 +1183,11 @@ version = "1.26.0"
 dependencies = [
  "anyhow",
  "crossterm",
+ "image",
  "mmdflux",
  "pulldown-cmark",
  "ratatui",
+ "ratatui-image",
  "reqwest",
  "semver",
  "serde",
@@ -1035,13 +1211,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "line-clipping"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1078,11 +1266,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1180,12 +1368,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1235,6 +1433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1264,7 +1463,7 @@ version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -1287,6 +1486,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "bytemuck",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1426,6 +1665,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,7 +1732,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -1492,6 +1744,38 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quantette"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c98fecda8b16396ff9adac67644a523dd1778c42b58606a29df5c31ca925d174"
+dependencies = [
+ "bitvec",
+ "bytemuck",
+ "image",
+ "libm",
+ "num-traits",
+ "ordered-float 5.3.0",
+ "palette",
+ "rand 0.9.4",
+ "rand_xoshiro",
+ "rayon",
+ "ref-cast",
+ "wide",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
@@ -1570,11 +1854,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -1584,8 +1876,18 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1603,6 +1905,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -1614,32 +1919,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "ratatui"
-version = "0.30.0"
+name = "rand_xoshiro"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
 dependencies = [
  "instability",
  "ratatui-core",
  "ratatui-crossterm",
  "ratatui-macros",
+ "ratatui-termina",
  "ratatui-termwiz",
  "ratatui-widgets",
+ "serde",
 ]
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "compact_str",
- "hashbrown 0.16.1",
- "indoc",
+ "critical-section",
+ "hashbrown 0.17.1",
  "itertools",
  "kasuari",
  "lru",
+ "palette",
+ "serde",
  "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -1649,9 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -1660,20 +1978,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "ratatui-macros"
-version = "0.7.0"
+name = "ratatui-image"
+version = "11.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+checksum = "e000b7a22eae639460bc6ec8bb1cc689ecae5b0ed21935cd7d7dd52d38270c86"
+dependencies = [
+ "base64-simd",
+ "icy_sixel",
+ "image",
+ "rand 0.8.6",
+ "ratatui",
+ "rustix 0.38.44",
+ "self_cell",
+ "thiserror 1.0.69",
+ "windows",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
 ]
 
 [[package]]
-name = "ratatui-termwiz"
+name = "ratatui-termina"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -1681,21 +2027,42 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.16.1",
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
  "indoc",
  "instability",
  "itertools",
  "line-clipping",
  "ratatui-core",
+ "serde",
  "strum",
  "time",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1704,7 +2071,27 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1807,14 +2194,27 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1866,6 +2266,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safe_arch"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629516c85c29fe757770fa03f2074cf1eac43d44c02a3de9fc2ef7b0e207dfdd"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1879,6 +2288,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -2061,18 +2476,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2147,6 +2562,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.0",
+ "parking_lot",
+ "rustix 1.1.4",
+ "signal-hook",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "terminfo"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2175,7 +2609,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -2188,7 +2622,7 @@ dependencies = [
  "nix",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 4.6.0",
  "pest",
  "pest_derive",
  "phf",
@@ -2390,7 +2824,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -2589,6 +3023,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
 name = "vtparse"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2723,7 +3163,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2757,6 +3197,12 @@ checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wezterm-bidi"
@@ -2800,7 +3246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float",
+ "ordered-float 4.6.0",
  "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
@@ -2828,6 +3274,16 @@ dependencies = [
  "lazy_static",
  "serde",
  "wezterm-dynamic",
+]
+
+[[package]]
+name = "wide"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ca908d26e4786149c48efcf6c0ea09ab0e06d1fe3c17dc1b4b0f1ca4a7e788"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -2862,10 +3318,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -3016,7 +3536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",
@@ -3051,6 +3571,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xterm-color"
@@ -3166,3 +3695,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ sha2          = "0.10"
 toml          = "0.8"
 unicodeit     = "0.2"
 mmdflux       = "2.5"
+ratatui-image = { version = "11", default-features = false, features = ["crossterm"] }
+image         = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp", "bmp"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 crossterm     = { version = "0.29", features = ["use-dev-tty"] }

--- a/src/app/content.rs
+++ b/src/app/content.rs
@@ -34,6 +34,7 @@ impl App {
             line_number_map,
             source_line_map,
             code_blocks,
+            images,
         } = parsed;
 
         self.plain_lines = build_searchable_lines(&lines)
@@ -49,6 +50,7 @@ impl App {
         self.set_code_blocks(code_blocks);
         self.code_select = None;
         self.set_line_maps(line_number_map, source_line_map);
+        self.images = images;
         self.refresh_static_caches();
     }
 
@@ -98,6 +100,7 @@ impl App {
         self.file_mode = is_code_file;
         let theme = current_syntect_theme(themes);
         let at = app_theme();
+        let base_path = path.parent().map(|p| p.to_path_buf());
         let parsed = parse_markdown_with_width(
             &src,
             ss,
@@ -106,6 +109,8 @@ impl App {
             &at.markdown,
             self.file_mode,
             self.code_line_numbers,
+            base_path.as_deref(),
+            &self.image_picker,
         );
 
         let first_load = self.filepath.is_none();
@@ -138,6 +143,7 @@ impl App {
         let theme = current_syntect_theme(themes);
         let at = app_theme();
         let old_total = self.total();
+        let base_path = self.filepath.as_deref().and_then(|p| p.parent());
         let parsed = parse_markdown_with_width(
             &self.source,
             ss,
@@ -146,6 +152,8 @@ impl App {
             &at.markdown,
             self.file_mode,
             self.code_line_numbers,
+            base_path,
+            &self.image_picker,
         );
         let new_total = parsed.lines.len();
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,12 +2,13 @@ use crate::{
     markdown::{
         build_searchable_lines,
         toc::{toc_levels, TocEntry},
-        CodeBlockInfo, LinkSpan,
+        CodeBlockInfo, ImageEntry, LinkSpan,
     },
     render::{build_status_bar, build_toc_line_with_index, toc_header_line},
     theme::{app_theme, current_theme_selection, theme_preset_index},
 };
 use ratatui::{layout::Rect, text::Line};
+use ratatui_image::picker::Picker;
 use std::{
     collections::HashMap,
     path::PathBuf,
@@ -147,6 +148,8 @@ pub(crate) struct App {
     pub(crate) hovered_link: Option<(usize, usize)>,
     pub(crate) code_blocks: Vec<CodeBlockInfo>,
     pub(crate) code_select: Option<usize>,
+    pub(crate) images: Vec<ImageEntry>,
+    pub(super) image_picker: Picker,
     code_block_flash: Option<(CodeBlockFlash, Instant)>,
     link_flash: Option<(LinkFlash, Instant)>,
     path_flash: Option<(PathFlash, Instant)>,
@@ -305,6 +308,8 @@ impl App {
             hovered_link: None,
             code_blocks: Vec::new(),
             code_select: None,
+            images: Vec::new(),
+            image_picker: Picker::halfblocks(),
             code_block_flash: None,
             link_flash: None,
             path_flash: None,
@@ -327,6 +332,14 @@ impl App {
 
     pub(crate) fn set_extras(&mut self, extras: Vec<String>) {
         self.file_picker.extras = extras;
+    }
+
+    pub(crate) fn set_image_picker(&mut self, picker: Picker) {
+        self.image_picker = picker;
+    }
+
+    pub(crate) fn set_images(&mut self, images: Vec<ImageEntry>) {
+        self.images = images;
     }
 
     pub(crate) fn set_file_mode(&mut self, file_mode: bool) {

--- a/src/app/theme_picker.rs
+++ b/src/app/theme_picker.rs
@@ -123,6 +123,7 @@ impl App {
 
         let theme = current_syntect_theme(themes);
         let at = app_theme();
+        let base_path = self.filepath.as_deref().and_then(|p| p.parent());
         let parsed = parse_markdown_with_width(
             &self.source,
             ss,
@@ -131,6 +132,8 @@ impl App {
             &at.markdown,
             self.file_mode,
             self.code_line_numbers,
+            base_path,
+            &self.image_picker,
         );
         self.store_theme_preview(preset, &parsed.lines, &parsed.toc);
         self.replace_content(parsed);
@@ -147,6 +150,7 @@ impl App {
             } else {
                 let theme = current_syntect_theme(themes);
                 let at = app_theme();
+                let base_path = self.filepath.as_deref().and_then(|p| p.parent());
                 let parsed = parse_markdown_with_width(
                     &self.source,
                     ss,
@@ -155,6 +159,8 @@ impl App {
                     &at.markdown,
                     self.file_mode,
                     self.code_line_numbers,
+                    base_path,
+                    &self.image_picker,
                 );
                 self.replace_content(parsed);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,8 @@ mod update;
 
 use app::{App, AppConfig};
 use cli::{parse_cli, print_usage, print_version, CliOptions};
-use markdown::{hash_str, parse_markdown, parse_markdown_with_width, read_file_state};
+use markdown::{hash_str, parse_markdown_with_width, read_file_state};
+use ratatui_image::picker::Picker;
 use runtime::run;
 use terminal::{finish_with_restore, TerminalSession};
 use theme::{
@@ -295,6 +296,22 @@ fn main() -> Result<()> {
         .unwrap_or("");
     let (src, file_mode) = App::wrap_as_code_block(src, ext, &ss);
 
+    // Must be created before entering raw mode / the alternate screen, since it queries the
+    // terminal for graphics-protocol and font-size capabilities. Inside tmux, that query's
+    // batched escape sequences can go unanswered; ratatui-image then leaves a background thread
+    // stuck reading stdin, which later resets the terminal out from under raw mode and hangs the
+    // app. tmux's own graphics passthrough is unreliable anyway, so skip the query there and
+    // fall back to halfblocks, which always works.
+    let image_picker = if std::env::var_os("TMUX").is_none()
+        && io::stdin().is_terminal()
+        && io::stdout().is_terminal()
+    {
+        Picker::from_query_stdio().unwrap_or_else(|_| Picker::halfblocks())
+    } else {
+        Picker::halfblocks()
+    };
+    let base_path = filepath.as_deref().and_then(|p| p.parent());
+
     if let Some(ref spec) = inline_spec {
         if src.is_empty() && filepath.is_none() {
             bail!("--inline requires a file path or stdin input");
@@ -313,6 +330,8 @@ fn main() -> Result<()> {
             &at.markdown,
             file_mode,
             code_line_numbers,
+            base_path,
+            &image_picker,
         );
 
         while parsed.lines.last().is_some_and(|l| {
@@ -329,13 +348,16 @@ fn main() -> Result<()> {
     }
 
     let at = app_theme();
-    let parsed = parse_markdown(
+    let parsed = parse_markdown_with_width(
         &src,
         &ss,
         &theme,
+        markdown::DEFAULT_RENDER_WIDTH,
         &at.markdown,
         file_mode,
         code_line_numbers,
+        base_path,
+        &image_picker,
     );
     let crate::markdown::ParseResult {
         lines,
@@ -344,6 +366,7 @@ fn main() -> Result<()> {
         line_number_map,
         source_line_map,
         code_blocks,
+        images,
     } = parsed;
     let mut app = App::new_with_source(
         lines,
@@ -360,6 +383,8 @@ fn main() -> Result<()> {
     app.set_link_spans(link_spans);
     app.set_code_blocks(code_blocks);
     app.set_line_maps(line_number_map, source_line_map);
+    app.set_images(images);
+    app.set_image_picker(image_picker);
     app.set_last_content_hash(last_content_hash);
     app.set_watch_from_config(watch_from_config);
     app.set_max_width(max_width);

--- a/src/markdown/images.rs
+++ b/src/markdown/images.rs
@@ -1,0 +1,57 @@
+use ratatui::layout::Size;
+use ratatui_image::{
+    picker::{Picker, ProtocolType},
+    sliced::SlicedProtocol,
+    Resize,
+};
+use std::path::{Path, PathBuf};
+
+/// A decoded, terminal-ready image placed at `rendered_start` in the parsed line buffer.
+pub(crate) struct ImageEntry {
+    pub(crate) rendered_start: usize,
+    pub(crate) slice: SlicedProtocol,
+}
+
+fn is_remote_url(dest: &str) -> bool {
+    dest.starts_with("http://") || dest.starts_with("https://") || dest.starts_with("data:")
+}
+
+fn resolve_image_path(dest: &str, base_path: Option<&Path>) -> PathBuf {
+    let path = Path::new(dest);
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    match base_path {
+        Some(base) => base.join(path),
+        None => path.to_path_buf(),
+    }
+}
+
+/// Decodes a local image and slices it to fit within `render_width` columns, preserving
+/// its aspect ratio via the terminal's font-cell size. Returns `None` for remote URLs,
+/// images that can't be read/decoded, or when the terminal has no real graphics protocol
+/// (halfblock art isn't worth the noise), in which case callers should fall back to a
+/// text placeholder.
+pub(crate) fn load_image(
+    dest: &str,
+    base_path: Option<&Path>,
+    render_width: usize,
+    picker: &Picker,
+) -> Option<(SlicedProtocol, usize)> {
+    if picker.protocol_type() == ProtocolType::Halfblocks {
+        return None;
+    }
+    if is_remote_url(dest) {
+        return None;
+    }
+    let path = resolve_image_path(dest, base_path);
+    let dyn_img = image::ImageReader::open(&path).ok()?.decode().ok()?;
+
+    let font_size = picker.font_size();
+    // Unbounded height: images are allowed to run tall and simply scroll, like code blocks.
+    let bounds = Size::new(render_width.max(1) as u16, u16::MAX);
+    let size = Resize::Fit(None).size_for(&dyn_img, font_size, bounds);
+    let slice = SlicedProtocol::new_with_resize(picker, dyn_img, size, Resize::Fit(None)).ok()?;
+    let height = (slice.size().height as usize).max(1);
+    Some((slice, height))
+}

--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -2,6 +2,7 @@ mod blocks;
 mod fences;
 mod frontmatter;
 mod highlight;
+mod images;
 mod latex;
 mod links;
 mod lists;
@@ -16,6 +17,7 @@ pub(crate) mod width;
 mod wrapping;
 
 pub(crate) use highlight::highlight_line;
+pub(crate) use images::ImageEntry;
 pub(crate) use links::LinkSpan;
 pub(crate) use syntax::resolve_syntax;
 use tables::{handle_table_event, start_table, TableBuf};
@@ -31,10 +33,11 @@ use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
 };
+use ratatui_image::picker::Picker;
 use std::{
     hash::{Hash, Hasher},
     io,
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 use toc::{normalize_toc, TocEntry};
 
@@ -82,7 +85,7 @@ pub(crate) fn hash_file_contents(path: &PathBuf) -> io::Result<u64> {
     std::fs::read_to_string(path).map(|contents| hash_str(&contents))
 }
 
-const DEFAULT_RENDER_WIDTH: usize = 80;
+pub(crate) const DEFAULT_RENDER_WIDTH: usize = 80;
 
 fn heading_level(level: HeadingLevel) -> u8 {
     match level {
@@ -255,6 +258,7 @@ pub(crate) struct ParseResult {
     pub(crate) line_number_map: Vec<usize>,
     pub(crate) source_line_map: Vec<usize>,
     pub(crate) code_blocks: Vec<CodeBlockInfo>,
+    pub(crate) images: Vec<ImageEntry>,
 }
 
 impl ParseResult {
@@ -266,6 +270,7 @@ impl ParseResult {
             line_number_map: Vec::new(),
             source_line_map: Vec::new(),
             code_blocks: Vec::new(),
+            images: Vec::new(),
         }
     }
 }
@@ -277,6 +282,7 @@ impl From<ParseResult> for (Vec<Line<'static>>, Vec<TocEntry>, Vec<LinkSpan>, Ve
     }
 }
 
+#[cfg(test)]
 pub(crate) fn parse_markdown(
     src: &str,
     ss: &syntect::parsing::SyntaxSet,
@@ -293,9 +299,12 @@ pub(crate) fn parse_markdown(
         md_theme,
         file_mode,
         code_line_numbers,
+        None,
+        &Picker::halfblocks(),
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn parse_markdown_with_width(
     src: &str,
     ss: &syntect::parsing::SyntaxSet,
@@ -304,6 +313,8 @@ pub(crate) fn parse_markdown_with_width(
     theme_colors: &MarkdownTheme,
     file_mode: bool,
     code_line_numbers: bool,
+    base_path: Option<&Path>,
+    image_picker: &Picker,
 ) -> ParseResult {
     let original_src = src;
     let (src, fm_pairs) = frontmatter::extract_frontmatter(src);
@@ -336,6 +347,8 @@ pub(crate) fn parse_markdown_with_width(
     let mut last_block = LastBlock::Other;
     let mut link_urls: Vec<String> = Vec::new();
     let mut blockquote_color: Option<Color> = None;
+    let mut image_entries: Vec<ImageEntry> = Vec::new();
+    let mut in_image: Option<(String, String)> = None;
 
     let normalized = normalize_code_fences(src);
     let line_starts = compute_line_starts(&normalized);
@@ -370,10 +383,49 @@ pub(crate) fn parse_markdown_with_width(
             continue;
         }
 
+        if let Some((_, alt)) = in_image.as_mut() {
+            match &ev {
+                MdEvent::Text(text) | MdEvent::Code(text) => {
+                    alt.push_str(text.as_ref());
+                    continue;
+                }
+                _ => {}
+            }
+        }
+
         let mut wraps = false;
         match ev {
             MdEvent::Start(Tag::Table(aligns)) => {
                 start_table(&mut table, &aligns);
+            }
+            MdEvent::Start(Tag::Image { dest_url, .. }) => {
+                if !spans.is_empty() {
+                    lines.push(Line::from(std::mem::take(&mut spans)));
+                }
+                in_image = Some((dest_url.to_string(), String::new()));
+            }
+            MdEvent::End(TagEnd::Image) => {
+                if let Some((dest_url, alt)) = in_image.take() {
+                    match images::load_image(&dest_url, base_path, render_width, image_picker) {
+                        Some((slice, height)) => {
+                            let rendered_start = lines.len();
+                            for _ in 0..height {
+                                lines.push(Line::from(""));
+                            }
+                            image_entries.push(ImageEntry {
+                                rendered_start,
+                                slice,
+                            });
+                        }
+                        None => {
+                            lines.push(Line::from(Span::styled(
+                                format!("[img: {alt}]"),
+                                Style::default().fg(theme_colors.code_gutter),
+                            )));
+                        }
+                    }
+                }
+                last_block = LastBlock::Other;
             }
             MdEvent::Start(Tag::Heading { level, .. }) => {
                 start_heading(&mut in_heading, level);
@@ -641,6 +693,7 @@ pub(crate) fn parse_markdown_with_width(
         line_number_map: state.line_number_map,
         source_line_map: state.source_line_map,
         code_blocks,
+        images: image_entries,
     }
 }
 

--- a/src/render/content.rs
+++ b/src/render/content.rs
@@ -6,6 +6,7 @@ use ratatui::{
     widgets::{Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, Wrap},
     Frame,
 };
+use ratatui_image::sliced::SlicedImage;
 
 use super::{CONTENT_HORIZONTAL_PADDING, SCROLLBAR_WIDTH};
 
@@ -102,6 +103,8 @@ pub(super) fn render_content_panel(f: &mut Frame, app: &mut App, area: Rect) {
         content_area,
     );
 
+    render_images(f, app, content_area, scroll, visible_end);
+
     let (mouse_col, mouse_row) = app.mouse_position;
     let sb_x = area.x + area.width - SCROLLBAR_WIDTH;
     let on_sb_column = mouse_col >= sb_x
@@ -132,6 +135,22 @@ pub(super) fn render_content_panel(f: &mut Frame, app: &mut App, area: Rect) {
 
     let mut scrollbar_state = ScrollbarState::new(max_scroll).position(app.scroll());
     f.render_stateful_widget(scrollbar, area, &mut scrollbar_state);
+}
+
+fn render_images(f: &mut Frame, app: &App, content_area: Rect, scroll: usize, visible_end: usize) {
+    for entry in &app.images {
+        let start = entry.rendered_start;
+        let end = start + entry.slice.size().height as usize;
+        if end <= scroll || start >= visible_end {
+            continue;
+        }
+        let position_y =
+            (start as i64 - scroll as i64).clamp(i16::MIN as i64, i16::MAX as i64) as i16;
+        f.render_widget(
+            SlicedImage::new(&entry.slice, (0, position_y).into()),
+            content_area,
+        );
+    }
 }
 
 fn inner_content_area(area: Rect) -> Rect {

--- a/src/tests/app.rs
+++ b/src/tests/app.rs
@@ -4,6 +4,7 @@ use crate::cli::parse_cli;
 use crate::markdown::{hash_str, parse_markdown, parse_markdown_with_width, read_file_state};
 use crate::*;
 use crossterm::event::KeyEventKind;
+use ratatui_image::picker::Picker;
 use std::{
     fs,
     time::{SystemTime, UNIX_EPOCH},
@@ -463,8 +464,18 @@ fn sync_render_width_preserves_scroll_proportion() {
         })
         .collect::<Vec<_>>()
         .join("\n\n");
-    let (lines, toc, _, _) =
-        parse_markdown_with_width(&source, &ss, &theme, 80, &test_md_theme(), false, true).into();
+    let (lines, toc, _, _) = parse_markdown_with_width(
+        &source,
+        &ss,
+        &theme,
+        80,
+        &test_md_theme(),
+        false,
+        true,
+        None,
+        &Picker::halfblocks(),
+    )
+    .into();
     let mut app = App::new_with_source(
         lines,
         toc,
@@ -528,8 +539,18 @@ fn sync_render_width_returns_false_when_clamped_width_is_unchanged() {
     let (ss, theme) = test_assets();
     let ts = ThemeSet::load_defaults();
     let source = "One paragraph that does not matter much for this width clamp test.";
-    let (lines, toc, _, _) =
-        parse_markdown_with_width(source, &ss, &theme, 20, &test_md_theme(), false, true).into();
+    let (lines, toc, _, _) = parse_markdown_with_width(
+        source,
+        &ss,
+        &theme,
+        20,
+        &test_md_theme(),
+        false,
+        true,
+        None,
+        &Picker::halfblocks(),
+    )
+    .into();
     let mut app = App::new_with_source(
         lines,
         toc,
@@ -547,9 +568,19 @@ fn sync_render_width_returns_false_when_clamped_width_is_unchanged() {
     assert!(!app.sync_render_width(10, &ss, &ts));
     assert_eq!(
         app.total(),
-        parse_markdown_with_width(source, &ss, &theme, 20, &test_md_theme(), false, true)
-            .lines
-            .len()
+        parse_markdown_with_width(
+            source,
+            &ss,
+            &theme,
+            20,
+            &test_md_theme(),
+            false,
+            true,
+            None,
+            &Picker::halfblocks()
+        )
+        .lines
+        .len()
     );
 }
 

--- a/src/tests/markdown_blocks.rs
+++ b/src/tests/markdown_blocks.rs
@@ -1,6 +1,7 @@
 use super::{rendered_non_empty_lines, test_assets, test_md_theme};
 use crate::markdown::{parse_markdown, parse_markdown_with_width};
 use crate::*;
+use ratatui_image::picker::Picker;
 
 #[test]
 fn h1_headings_render_double_rule_without_bottom_spacing() {
@@ -43,8 +44,18 @@ fn nested_blockquotes_keep_quote_prefix_after_inner_quote_ends() {
 fn long_blockquotes_wrap_into_multiple_prefixed_lines() {
     let (ss, theme) = test_assets();
     let src = "> This is a long blockquote line that should wrap into multiple quoted lines at narrow widths.\n";
-    let (lines, _, _, _) =
-        parse_markdown_with_width(src, &ss, &theme, 28, &test_md_theme(), false, true).into();
+    let (lines, _, _, _) = parse_markdown_with_width(
+        src,
+        &ss,
+        &theme,
+        28,
+        &test_md_theme(),
+        false,
+        true,
+        None,
+        &Picker::halfblocks(),
+    )
+    .into();
     let rendered = rendered_non_empty_lines(&lines);
     let quoted: Vec<_> = rendered
         .into_iter()
@@ -77,6 +88,8 @@ fn h2_headings_are_underlined_and_compact() {
         &test_md_theme(),
         false,
         true,
+        None,
+        &Picker::halfblocks(),
     )
     .into();
     let rendered = rendered_non_empty_lines(&lines);
@@ -96,6 +109,8 @@ fn rules_use_render_width_without_extra_blank_after() {
         &test_md_theme(),
         false,
         true,
+        None,
+        &Picker::halfblocks(),
     )
     .into();
     let rendered = rendered_non_empty_lines(&lines);
@@ -113,8 +128,18 @@ fn rules_use_render_width_without_extra_blank_after() {
 fn body_dashes_are_thematic_breaks_not_metadata_block() {
     let (ss, theme) = test_assets();
     let src = "# Title\n\n---\n### SSL\n\n- item 1\n- item 2\n\n---\n### TLS\nend\n";
-    let (lines, _, _, _) =
-        parse_markdown_with_width(src, &ss, &theme, 40, &test_md_theme(), false, true).into();
+    let (lines, _, _, _) = parse_markdown_with_width(
+        src,
+        &ss,
+        &theme,
+        40,
+        &test_md_theme(),
+        false,
+        true,
+        None,
+        &Picker::halfblocks(),
+    )
+    .into();
     let rendered = rendered_non_empty_lines(&lines);
 
     let rule_count = rendered

--- a/src/tests/markdown_images.rs
+++ b/src/tests/markdown_images.rs
@@ -1,0 +1,138 @@
+use super::{test_assets, test_md_theme};
+use crate::markdown::parse_markdown_with_width;
+use image::{Rgb, RgbImage};
+use ratatui_image::picker::{Picker, ProtocolType};
+use std::path::PathBuf;
+
+fn picker_with_protocol(protocol: ProtocolType) -> Picker {
+    let mut picker = Picker::halfblocks();
+    picker.set_protocol_type(protocol);
+    picker
+}
+
+fn write_test_png(name: &str) -> (PathBuf, PathBuf) {
+    let dir = std::env::temp_dir().join(format!(
+        "leaf-image-test-{}-{}",
+        std::process::id(),
+        name.replace('.', "_")
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(name);
+    RgbImage::from_pixel(20, 20, Rgb([200, 50, 50]))
+        .save(&path)
+        .expect("write test png");
+    (dir, path)
+}
+
+#[test]
+fn local_image_is_decoded_and_reserves_lines() {
+    let (ss, theme) = test_assets();
+    let (dir, _path) = write_test_png("pic.png");
+
+    let src = "![a pic](pic.png)\n";
+    let picker = picker_with_protocol(ProtocolType::Kitty);
+    let parsed = parse_markdown_with_width(
+        src,
+        &ss,
+        &theme,
+        40,
+        &test_md_theme(),
+        false,
+        true,
+        Some(dir.as_path()),
+        &picker,
+    );
+
+    assert_eq!(parsed.images.len(), 1);
+    let entry = &parsed.images[0];
+    let height = entry.slice.size().height as usize;
+    assert!(height > 0);
+    assert!(parsed.lines.len() >= entry.rendered_start + height);
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn halfblocks_only_terminal_falls_back_to_placeholder() {
+    let (ss, theme) = test_assets();
+    let (dir, _path) = write_test_png("pic.png");
+
+    let src = "![a pic](pic.png)\n";
+    let picker = Picker::halfblocks();
+    let parsed = parse_markdown_with_width(
+        src,
+        &ss,
+        &theme,
+        40,
+        &test_md_theme(),
+        false,
+        true,
+        Some(dir.as_path()),
+        &picker,
+    );
+
+    assert!(parsed.images.is_empty());
+    let text: String = parsed
+        .lines
+        .iter()
+        .flat_map(|l| l.spans.iter())
+        .map(|s| s.content.as_ref())
+        .collect();
+    assert!(text.contains("[img: a pic]"));
+
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn missing_image_falls_back_to_placeholder() {
+    let (ss, theme) = test_assets();
+    let src = "![missing alt](does-not-exist.png)\n";
+    let picker = picker_with_protocol(ProtocolType::Kitty);
+    let parsed = parse_markdown_with_width(
+        src,
+        &ss,
+        &theme,
+        40,
+        &test_md_theme(),
+        false,
+        true,
+        None,
+        &picker,
+    );
+
+    assert!(parsed.images.is_empty());
+    let text: String = parsed
+        .lines
+        .iter()
+        .flat_map(|l| l.spans.iter())
+        .map(|s| s.content.as_ref())
+        .collect();
+    assert!(text.contains("[img: missing alt]"));
+}
+
+#[test]
+fn remote_image_url_falls_back_to_placeholder_without_fetching() {
+    let (ss, theme) = test_assets();
+    let src = "![remote](https://example.com/a.png)\n";
+    let picker = picker_with_protocol(ProtocolType::Kitty);
+    let parsed = parse_markdown_with_width(
+        src,
+        &ss,
+        &theme,
+        40,
+        &test_md_theme(),
+        false,
+        true,
+        None,
+        &picker,
+    );
+
+    assert!(parsed.images.is_empty());
+    let text: String = parsed
+        .lines
+        .iter()
+        .flat_map(|l| l.spans.iter())
+        .map(|s| s.content.as_ref())
+        .collect();
+    assert!(text.contains("[img: remote]"));
+}

--- a/src/tests/markdown_lists.rs
+++ b/src/tests/markdown_lists.rs
@@ -2,6 +2,7 @@ use super::{rendered_non_empty_lines, test_assets, test_md_theme};
 use crate::markdown::{parse_markdown, parse_markdown_with_width};
 use crate::markdown::{TASK_CHECKED, TASK_CHECKED_ALT, TASK_UNCHECKED};
 use crate::*;
+use ratatui_image::picker::Picker;
 
 #[test]
 fn loose_list_items_keep_their_markers() {
@@ -162,8 +163,18 @@ fn paragraph_and_following_list_have_no_blank_gap() {
 fn wrapped_list_items_align_continuation_under_text() {
     let (ss, theme) = test_assets();
     let src = "- First item with enough text to wrap when the terminal is narrow and show continuation alignment.\n8. Eighth item with enough text to wrap and keep numeric alignment readable.\n";
-    let (lines, _, _, _) =
-        parse_markdown_with_width(src, &ss, &theme, 36, &test_md_theme(), false, true).into();
+    let (lines, _, _, _) = parse_markdown_with_width(
+        src,
+        &ss,
+        &theme,
+        36,
+        &test_md_theme(),
+        false,
+        true,
+        None,
+        &Picker::halfblocks(),
+    )
+    .into();
     let rendered = rendered_non_empty_lines(&lines);
 
     assert!(rendered.iter().any(|line| line.starts_with("• First item")));
@@ -226,8 +237,18 @@ fn tight_nested_list_multiline_parent_with_softbreak() {
 fn wrapped_list_inline_code_keeps_left_padding_in_rendered_line() {
     let (ss, theme) = test_assets();
     let source = "- `leaf --theme ocean README.md` exercises wrapping inside a list item.\n";
-    let (lines, _, _, _) =
-        parse_markdown_with_width(source, &ss, &theme, 22, &test_md_theme(), false, true).into();
+    let (lines, _, _, _) = parse_markdown_with_width(
+        source,
+        &ss,
+        &theme,
+        22,
+        &test_md_theme(),
+        false,
+        true,
+        None,
+        &Picker::halfblocks(),
+    )
+    .into();
 
     let target = lines
         .iter()

--- a/src/tests/markdown_tables.rs
+++ b/src/tests/markdown_tables.rs
@@ -2,13 +2,24 @@ use super::{rendered_non_empty_lines, test_assets, test_md_theme};
 use crate::markdown::{parse_markdown, parse_markdown_with_width};
 use crate::theme::app_theme;
 use crate::*;
+use ratatui_image::picker::Picker;
 
 #[test]
 fn narrow_tables_fit_render_width_and_wrap_cells() {
     let (ss, theme) = test_assets();
     let md = "| Column | Description | Value |\n| --- | --- | ---: |\n| Width | Terminal-dependent layout behavior | 80 |\n";
-    let (lines, _, _, _) =
-        parse_markdown_with_width(md, &ss, &theme, 36, &test_md_theme(), false, true).into();
+    let (lines, _, _, _) = parse_markdown_with_width(
+        md,
+        &ss,
+        &theme,
+        36,
+        &test_md_theme(),
+        false,
+        true,
+        None,
+        &Picker::halfblocks(),
+    )
+    .into();
     let rendered = rendered_non_empty_lines(&lines);
 
     assert!(rendered.len() >= 6);
@@ -177,8 +188,18 @@ fn table_long_inline_code_wraps_without_clipping() {
     let code = "verylonginlinecodethatcannotfitinasinglenarrowcolumn";
     let md = format!("| Description |\n|---|\n| `{code}` |\n");
     let width = 24;
-    let (lines, _, _, _) =
-        parse_markdown_with_width(&md, &ss, &theme, width, &test_md_theme(), false, true).into();
+    let (lines, _, _, _) = parse_markdown_with_width(
+        &md,
+        &ss,
+        &theme,
+        width,
+        &test_md_theme(),
+        false,
+        true,
+        None,
+        &Picker::halfblocks(),
+    )
+    .into();
     let rendered = rendered_non_empty_lines(&lines);
     let theme_colors = &app_theme().markdown;
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -21,6 +21,7 @@ mod file_picker;
 mod inline;
 mod markdown_blocks;
 mod markdown_embedded;
+mod markdown_images;
 mod markdown_links;
 mod markdown_lists;
 mod markdown_tables;

--- a/src/tests/render.rs
+++ b/src/tests/render.rs
@@ -3,6 +3,7 @@ use crate::app::App;
 use crate::markdown::{parse_markdown, parse_markdown_with_width};
 use crate::wrap_path_lines;
 use ratatui::style::Style;
+use ratatui_image::picker::Picker;
 
 #[test]
 fn code_block_box_renders_right_border_in_one_column() {
@@ -36,6 +37,8 @@ fn file_mode_code_block_fills_full_render_width() {
         &test_md_theme(),
         true,
         true,
+        None,
+        &Picker::halfblocks(),
     )
     .into();
     let buffer = render_buffer(&lines);


### PR DESCRIPTION
## Summary
- Render inline markdown images (`![alt](path)`) using `ratatui-image`'s `SlicedProtocol`, which supports Kitty, Sixel, and iTerm2 and correctly crops images that are partially scrolled in/out of the viewport.
- Terminals without a real graphics protocol (halfblocks-only, e.g. tmux) show a `[img: alt]` placeholder instead of ANSI block art. Remote URLs and undecodable images fall back the same way, with no network I/O.
- The graphics-capability query runs once at startup before raw mode is entered, and is skipped under tmux specifically — its batched query sequences can go unanswered there, leaving a background reader thread stuck and corrupting terminal state for ratatui's own subsequent cursor-position query, which hung the app at startup.

Closes #199

## Test plan
- [x] `cargo test` (308 passed)
- [x] `cargo clippy --all-targets`
- [x] `cargo fmt --check`
- [x] Manually verified in a live tmux session: correct 24-bit color halfblock-protocol image render, scrolling, and clean exit/restore, before switching to placeholder-only for halfblocks terminals
- [x] Manually verified placeholder fallback (`[img: alt]`) renders under tmux (no real graphics protocol)

🤖 Generated with [Claude Code](https://claude.com/claude-code)