### PR TITLE
fix: code block in tight list

### DIFF
--- a/src/markdown/mod.rs
+++ b/src/markdown/mod.rs
@@ -405,6 +405,19 @@ pub(crate) fn parse_markdown_with_width(
                 last_block = LastBlock::Paragraph;
             }
             MdEvent::Start(Tag::CodeBlock(kind)) => {
+                if !spans.is_empty() {
+                    flush_wrapped_spans(
+                        &mut lines,
+                        &mut spans,
+                        blockquote_depth,
+                        &list_stack,
+                        &mut item_stack,
+                        render_width,
+                        theme_colors,
+                        blockquote_color,
+                    );
+                    wraps = true;
+                }
                 start_code_block(
                     &mut lines,
                     last_block,

--- a/src/tests/markdown_lists.rs
+++ b/src/tests/markdown_lists.rs
@@ -278,3 +278,34 @@ fn code_block_inside_list_item_is_indented_and_has_no_blank_gap_before() {
     assert!(rendered[header_idx].starts_with("  "));
     assert!(rendered[code_idx].starts_with("  "));
 }
+
+#[test]
+fn code_block_after_continuation_line_in_tight_list_item_renders_below_it() {
+    let (ss, theme) = test_assets();
+    let md = "- one\n  two\n  ```\n  three\n  ```\n";
+    let (lines, _, _, _) = parse_markdown(md, &ss, &theme, &test_md_theme(), false, true).into();
+    let rendered = rendered_non_empty_lines(&lines);
+
+    let one_idx = rendered
+        .iter()
+        .position(|line| line.contains("one"))
+        .expect("missing first list line");
+    let two_idx = rendered
+        .iter()
+        .position(|line| line.contains("two"))
+        .expect("missing continuation line");
+    let three_idx = rendered
+        .iter()
+        .position(|line| line.contains("three"))
+        .expect("missing code line");
+
+    assert!(
+        one_idx < two_idx && two_idx < three_idx,
+        "expected code block below continuation line, got one={one_idx}, two={two_idx}, three={three_idx}"
+    );
+    assert_eq!(
+        two_idx,
+        one_idx + 1,
+        "expected continuation line directly after first line"
+    );
+}


### PR DESCRIPTION
Fixed a bug where code blocks inside list items are displayed in wrong positions.

minimal reproduction is:
````markdown
- one
  two
  ```
  three
  ```
````

before:
<img width="407" height="115" alt="スクリーンショット 2026-07-10 16 20 06" src="https://github.com/user-attachments/assets/ddf4d5e0-a6db-4d35-a649-b855977f3f99" />

after:
<img width="407" height="95" alt="スクリーンショット 2026-07-10 16 16 41" src="https://github.com/user-attachments/assets/8c9d7457-e0d2-4571-ad2a-c956826499af" />
