### PR TITLE
Improve keyboard navigation: uppercase Q quit and more-style paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,8 +243,8 @@ See [`gruvbox.toml`](gruvbox.toml) for a complete example with all available col
 |---|---|---|---|
 | `j` / `↓` | Scroll down | `?` | Show help popup |
 | `k` / `↑` | Scroll up | `t` | Toggle TOC sidebar |
-| `d` / PgDn | Page down (20 lines) | `Shift+L` | Toggle line numbers |
-| `u` / PgUp | Page up (20 lines) | `Shift+T` | Open theme picker |
+| `d` / `Space` / PgDn | Page down (20 lines) | `Shift+L` | Toggle line numbers |
+| `u` / `b` / PgUp | Page up (20 lines) | `Shift+T` | Open theme picker |
 | `g` / Home | Top | `Shift+E` | Open editor picker |
 | `G` / End | Bottom | `Shift+P` | Open file browser |
 | `Ctrl+L` | Go to line | `Ctrl+P` | Open fuzzy picker |

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ See [`gruvbox.toml`](gruvbox.toml) for a complete example with all available col
 | `n` / `N` | Next / prev match | `Ctrl+Click` | Open link |
 | `w` | Toggle watch mode | `Double-Click` | Copy link |
 | `r` | Force reload (watch mode) | `Shift+Drag` | Select text |
-| `q` | Quit | `Option+Drag` | Select text (iTerm2) |
+| `q` / `Q` | Quit | `Option+Drag` | Select text (iTerm2) |
 
 ## Features
 

--- a/demo/sources/demo-mermaid-render.md
+++ b/demo/sources/demo-mermaid-render.md
@@ -14,5 +14,5 @@ sequenceDiagram
     participant L as Leaf
     U->>T: leaf README.md
     L-->>T: render preview
-    U->>L: q (quit)
+    U->>L: q/Q (quit)
 ```

--- a/demo/sources/demo-navigation.md
+++ b/demo/sources/demo-navigation.md
@@ -7,7 +7,7 @@ Move freely — keyboard and mouse navigation with interactive scrollbar.
 **Navigation** lets you move through documents with keyboard shortcuts, mouse wheel, and a draggable scrollbar.
 
 - `j`/`k` or arrows: scroll line by line
-- `d`/`u` or PageDown/PageUp: scroll by page
+- `d`/`Space` or PageDown: page down; `u`/`b` or PageUp: page up
 - `g`/`Shift+G` or Home/End: jump to top/bottom
 - Mouse wheel: scroll 3 lines per tick
 - Scrollbar: click and drag for fast positioning

--- a/src/render/popup.rs
+++ b/src/render/popup.rs
@@ -111,7 +111,7 @@ pub(super) fn render_help_popup(f: &mut Frame, _app: &App) {
             Span::styled("capture", text_style),
         ]),
         Line::from(vec![
-            Span::styled("u/d        ", key_style),
+            Span::styled("u/d spc/b  ", key_style),
             Span::styled("page up/down", text_style),
             Span::raw("     "),
             Span::styled("dbl-click   ", key_style),

--- a/src/render/popup.rs
+++ b/src/render/popup.rs
@@ -195,7 +195,7 @@ pub(super) fn render_help_popup(f: &mut Frame, _app: &App) {
             Span::styled("p          ", key_style),
             Span::styled("path viewer", text_style),
             Span::raw("      "),
-            Span::styled("q           ", key_style),
+            Span::styled("q/Q         ", key_style),
             Span::styled("quit", text_style),
         ]),
         Line::from(vec![

--- a/src/render/status.rs
+++ b/src/render/status.rs
@@ -183,7 +183,7 @@ pub(crate) fn status_hint_segments(app: &App) -> &'static [&'static str] {
     } else if app.has_active_search() {
         &["n/N next/prev", "esc cancel"]
     } else {
-        &["ctrl+e edit", "ctrl+f find", "t toc", "? help", "q quit"]
+        &["ctrl+e edit", "ctrl+f find", "t toc", "? help", "q/Q quit"]
     }
 }
 

--- a/src/runtime/keyboard.rs
+++ b/src/runtime/keyboard.rs
@@ -261,10 +261,12 @@ pub(super) fn handle_key_event(
             KeyCode::Esc if app.has_active_goto_line() => app.clear_active_goto_line(),
             KeyCode::Esc if app.has_active_search() => app.clear_active_search(),
             KeyCode::Enter if app.has_active_search() => app.next_match(),
-            KeyCode::Char('q') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            KeyCode::Char('q') | KeyCode::Char('Q')
+                if key.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
                 app.queue_fuzzy_file_picker(app.picker_dir());
             }
-            KeyCode::Char('q') => return Ok(HandleResult::Break),
+            KeyCode::Char('q') | KeyCode::Char('Q') => return Ok(HandleResult::Break),
             KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 if app.has_active_search() {
                     app.clear_active_search();

--- a/src/runtime/keyboard.rs
+++ b/src/runtime/keyboard.rs
@@ -278,8 +278,8 @@ pub(super) fn handle_key_event(
             }
             KeyCode::Char('j') | KeyCode::Down => app.scroll_down(1),
             KeyCode::Char('k') | KeyCode::Up => app.scroll_up(1),
-            KeyCode::Char('d') | KeyCode::PageDown => app.scroll_down(20),
-            KeyCode::Char('u') | KeyCode::PageUp => app.scroll_up(20),
+            KeyCode::Char('d') | KeyCode::Char(' ') | KeyCode::PageDown => app.scroll_down(20),
+            KeyCode::Char('u') | KeyCode::Char('b') | KeyCode::PageUp => app.scroll_up(20),
             KeyCode::Char('g') | KeyCode::Home => app.scroll_top(),
             KeyCode::Char('G') | KeyCode::End => app.scroll_bottom(),
             KeyCode::Char('J') if app.can_scroll_toc() => app.focus_next_top_level_toc(),


### PR DESCRIPTION
## Summary
- Accept uppercase `Q` as well as lowercase `q` to quit reading mode
- Keep `Ctrl+Q` consistent with `Ctrl+q` for opening the fuzzy file picker
- Add `more`-style paging: `Space` pages down, `b` pages up (same step as `d`/`u` / PgDn/PgUp)
- Update help popup and status bar hints (`q/Q quit`, `u/d spc/b`)
- Sync docs: README keybindings, Mermaid demo, and navigation demo

## Motivation
- **Quit with `Q`**: With a Chinese IME, switching to type lowercase `q` usually means leaving Chinese input first. With Caps Lock on, pressing `Q` exits without changing the input method.
- **Space / `b` paging**: Matches familiar `more`/`less` habits so one-handed paging is easier while reading.

## Test plan
- [x] `cargo build` (or `cargo run -- README.md`)
- [x] In reading mode, press `q` — app exits
- [x] In reading mode, press `Q` (or Caps Lock + Q) — app exits
- [x] In reading mode, press `Space` — page down (~20 lines)
- [x] In reading mode, press `b` — page up (~20 lines)
- [x] Confirm help (`?`) shows `q/Q quit` and `u/d spc/b`
- [x] Confirm status bar shows `q/Q quit`
- [x] Confirm README lists `q`/`Q`, `Space`, and `b`
- [x] Confirm `Ctrl+q` / `Ctrl+Q` still open the fuzzy file picker