### PR TITLE
chore: quit with uppercase Q

### DIFF
--- a/src/runtime/keyboard.rs
+++ b/src/runtime/keyboard.rs
@@ -264,7 +264,7 @@ pub(super) fn handle_key_event(
             KeyCode::Char('q') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 app.queue_fuzzy_file_picker(app.picker_dir());
             }
-            KeyCode::Char('q') => return Ok(HandleResult::Break),
+            KeyCode::Char('q') | KeyCode::Char('Q') => return Ok(HandleResult::Break),
             KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 if app.has_active_search() {
                     app.clear_active_search();


### PR DESCRIPTION
Add hidden `shift+q` shortcut as alias for `q` to quit the viewer.