### PR TITLE
feat: custom file picker width

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,13 +208,14 @@ leaf --config
 This opens the configuration file in your editor. If the file does not exist yet, **leaf** creates it with documented defaults.
 
 ```toml
-theme = "ocean"           # arctic, forest, ocean, solarized-dark, or a custom theme file
-editor = "nano"           # any editor in PATH
-watch = false             # auto-reload when opening a file
-width = 80                # maximum content width (min: 20, default: terminal width)
-extras = ["txt", "rs"]    # extra file types shown in the picker
-code-line-numbers = true  # show line numbers inside fenced code blocks
-tab-title-length = -1     # terminal tab title truncation (min: 20, -1: no truncation)
+theme = "ocean"            # arctic, forest, ocean, solarized-dark, or a custom theme file
+editor = "nano"            # any editor in PATH
+watch = false              # auto-reload when opening a file
+width = 80                 # maximum content width (min: 20, default: terminal width)
+extras = ["txt", "rs"]     # extra file types shown in the picker
+file-picker-width = "75%"  # width of the file picker (fuzzy + file browser)
+code-line-numbers = true   # show line numbers inside fenced code blocks
+tab-title-length = -1      # terminal tab title truncation (min: 20, -1: no truncation)
 ```
 
 To reset the configuration to defaults:

--- a/config.toml
+++ b/config.toml
@@ -66,6 +66,17 @@ watch = false
 # Default: [] (Markdown only)
 # extras = ["txt", "csv", "rs", "java", "json", "yaml"]
 
+# Width of the file picker (fuzzy + file browser)
+# Accepted formats:
+#   "NN%":     percent of terminal width, converted to cells (ceil)
+#   "NNcells": absolute number of terminal cells
+# The final width is always capped by (terminal_width - 2) cells.
+#
+# Priority: LEAF_FILE_PICKER_WIDTH > this setting > default ("78cells")
+# Minimum: 78 cells. Applies to both formats.
+# Default: "78cells"
+# file-picker-width = "78cells"
+
 # Show line numbers inside fenced code blocks
 # Only affects code block gutters, the main document line numbers are independent.
 # Priority: LEAF_CODE_LINE_NUMBERS > this setting > default (true)

--- a/src/app/file_picker.rs
+++ b/src/app/file_picker.rs
@@ -346,11 +346,13 @@ impl App {
         self.file_picker.match_positions.clear();
         self.file_picker.index = 0;
         self.file_picker.truncation = None;
+        self.picker_width_floor_active = false;
     }
 
     pub(crate) fn cancel_picker_loading(&mut self) {
         self.picker_load_state = PickerLoadState::Idle;
         self.pending_picker = PendingPicker::None;
+        self.picker_width_floor_active = false;
     }
 
     pub(crate) fn file_picker_dir(&self) -> &std::path::Path {

--- a/src/app/flash.rs
+++ b/src/app/flash.rs
@@ -1,5 +1,6 @@
 use super::App;
 use crate::markdown::hash_str;
+use crate::picker_width as pw;
 use std::time::Instant;
 
 pub(crate) const FLASH_DURATION_MS: u64 = 1500;
@@ -108,6 +109,24 @@ impl App {
         if let Some(msg) = warning {
             self.config_flash = Some((msg, Instant::now()));
         }
+    }
+
+    pub(crate) fn refresh_picker_width_floor(&mut self, area_width: u16) -> u16 {
+        let raw = pw::picker_width_raw(self.file_picker_width, area_width);
+        let below_floor = raw < pw::PICKER_WIDTH_FLOOR_CELLS;
+
+        let cap = area_width.saturating_sub(2);
+        let floor_has_visible_effect = raw.min(cap) != pw::PICKER_WIDTH_FLOOR_CELLS.min(cap);
+        let should_signal = below_floor && floor_has_visible_effect;
+
+        if should_signal && !self.picker_width_floor_active {
+            self.set_config_warning(Some(pw::PICKER_WIDTH_FLOOR_WARNING.to_string()));
+            self.picker_width_floor_active = true;
+        } else if !should_signal {
+            self.picker_width_floor_active = false;
+        }
+
+        raw.max(pw::PICKER_WIDTH_FLOOR_CELLS)
     }
 
     pub(crate) fn config_flash(&self) -> Option<(&str, &Instant)> {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -170,6 +170,8 @@ pub(crate) struct App {
     max_width: Option<usize>,
     tab_title_max_filename_len: Option<usize>,
     tab_title_length: Option<i32>,
+    file_picker_width: crate::picker_width::PickerWidthSpec,
+    pub(super) picker_width_floor_active: bool,
     mouse_capture: bool,
 }
 
@@ -330,6 +332,8 @@ impl App {
             max_width: None,
             tab_title_max_filename_len: None,
             tab_title_length: None,
+            file_picker_width: crate::picker_width::DEFAULT_PICKER_WIDTH,
+            picker_width_floor_active: false,
             mouse_capture: true,
         };
         app.store_current_theme_preview();
@@ -367,6 +371,10 @@ impl App {
 
     pub(crate) fn tab_title_length(&self) -> Option<i32> {
         self.tab_title_length
+    }
+
+    pub(crate) fn set_file_picker_width(&mut self, value: crate::picker_width::PickerWidthSpec) {
+        self.file_picker_width = value;
     }
 
     pub(crate) fn is_mouse_capture_enabled(&self) -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use std::{
 use anyhow::Context;
 use serde::{Deserialize, Deserializer};
 
+use crate::picker_width::{parse_picker_width_spec, PickerWidthSpec};
 use crate::theme::{resolve_theme_selection, CustomThemeConfig};
 
 const DEFAULT_CONFIG: &str = include_str!("../config.toml");
@@ -26,6 +27,11 @@ pub(crate) struct LeafConfig {
         deserialize_with = "deserialize_lenient_i32"
     )]
     pub(crate) tab_title_length: Option<i32>,
+    #[serde(
+        rename = "file-picker-width",
+        deserialize_with = "deserialize_lenient_picker_width"
+    )]
+    pub(crate) file_picker_width: Option<PickerWidthSpec>,
     pub(crate) themes: BTreeMap<String, CustomThemeConfig>,
     #[serde(skip)]
     pub(crate) config_dir: Option<PathBuf>,
@@ -37,6 +43,16 @@ where
 {
     let value = toml::Value::deserialize(deserializer)?;
     Ok(value.as_integer().and_then(|n| i32::try_from(n).ok()))
+}
+
+fn deserialize_lenient_picker_width<'de, D>(
+    deserializer: D,
+) -> Result<Option<PickerWidthSpec>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = toml::Value::deserialize(deserializer)?;
+    Ok(value.as_str().and_then(parse_picker_width_spec))
 }
 
 #[derive(Default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod config;
 mod editor;
 mod inline;
 mod markdown;
+mod picker_width;
 mod render;
 mod runtime;
 mod terminal;
@@ -138,6 +139,17 @@ pub(crate) fn tab_title_n_to_max_filename_len(n: i32) -> Option<usize> {
     max_filename_len_for_prefix(n, LEAF_TAB_PREFIX_LEN)
 }
 
+pub(crate) fn resolve_file_picker_width(
+    config_value: Option<picker_width::PickerWidthSpec>,
+) -> picker_width::PickerWidthSpec {
+    if let Ok(val) = std::env::var("LEAF_FILE_PICKER_WIDTH") {
+        if let Some(spec) = picker_width::parse_picker_width_spec(&val) {
+            return spec;
+        }
+    }
+    config_value.unwrap_or(picker_width::DEFAULT_PICKER_WIDTH)
+}
+
 fn append_config_warning(warning: &mut Option<String>, next: Option<String>) {
     let Some(next) = next else {
         return;
@@ -222,6 +234,7 @@ fn main() -> Result<()> {
     let code_line_numbers = resolve_code_line_numbers(user_config.code_line_numbers);
     let tab_title_length = resolve_tab_title_length_n(user_config.tab_title_length);
     let tab_title_max_filename_len = tab_title_length.and_then(tab_title_n_to_max_filename_len);
+    let file_picker_width = resolve_file_picker_width(user_config.file_picker_width);
 
     if let Some(ref mut spec) = inline_spec {
         if spec.width.is_none() {
@@ -399,6 +412,7 @@ fn main() -> Result<()> {
     app.set_max_width(max_width);
     app.set_tab_title_max_filename_len(tab_title_max_filename_len);
     app.set_tab_title_length(tab_title_length);
+    app.set_file_picker_width(file_picker_width);
     app.set_extras(user_config.extras);
     app.set_file_mode(file_mode);
     app.set_editor_config(Some(resolved_editor));

--- a/src/picker_width.rs
+++ b/src/picker_width.rs
@@ -1,0 +1,36 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PickerWidthSpec {
+    Percent(u8),
+    Cells(u16),
+}
+
+pub(crate) const DEFAULT_PICKER_WIDTH: PickerWidthSpec = PickerWidthSpec::Cells(78);
+pub(crate) const PICKER_WIDTH_FLOOR_CELLS: u16 = 78;
+pub(crate) const PICKER_WIDTH_FLOOR_WARNING: &str =
+    "Configured file picker width below minimum, floor applied";
+
+pub(crate) fn parse_picker_width_spec(s: &str) -> Option<PickerWidthSpec> {
+    let s = s.trim().to_ascii_lowercase();
+    if let Some(num) = s.strip_suffix('%') {
+        let n: u8 = num.parse().ok()?;
+        return (1..=100)
+            .contains(&n)
+            .then_some(PickerWidthSpec::Percent(n));
+    }
+    for suffix in ["cells", "cell"] {
+        if let Some(num) = s.strip_suffix(suffix) {
+            let n: u16 = num.parse().ok()?;
+            return (n >= 1).then_some(PickerWidthSpec::Cells(n));
+        }
+    }
+    None
+}
+
+pub(crate) fn picker_width_raw(spec: PickerWidthSpec, area_width: u16) -> u16 {
+    match spec {
+        PickerWidthSpec::Percent(p) => {
+            (area_width as u32).saturating_mul(p as u32).div_ceil(100) as u16
+        }
+        PickerWidthSpec::Cells(n) => n,
+    }
+}

--- a/src/render/popup_picker.rs
+++ b/src/render/popup_picker.rs
@@ -1,5 +1,6 @@
 use crate::{app::App, editor::EditorKind, theme::app_theme};
 use ratatui::{
+    layout::Rect,
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Padding, Paragraph},
@@ -11,9 +12,15 @@ use super::popup::{
     highlighted_picker_label, picker_truncation_message, popup_footer, popup_footer_line,
 };
 
-pub(super) fn render_file_popup(f: &mut Frame, app: &App) {
+fn file_picker_area(f: &Frame, app: &mut App) -> Rect {
+    let full = f.area();
+    let width = app.refresh_picker_width_floor(full.width);
+    centered_rect(width, 20, full)
+}
+
+pub(super) fn render_file_popup(f: &mut Frame, app: &mut App) {
     let theme = app_theme();
-    let area = centered_rect(78, 20, f.area());
+    let area = file_picker_area(f, app);
     let title_style = Style::default()
         .fg(theme.markdown.heading_2)
         .add_modifier(Modifier::BOLD);
@@ -176,9 +183,9 @@ pub(super) fn render_file_popup(f: &mut Frame, app: &App) {
     );
 }
 
-pub(super) fn render_picker_loading_popup(f: &mut Frame, app: &App) {
+pub(super) fn render_picker_loading_popup(f: &mut Frame, app: &mut App) {
     let theme = app_theme();
-    let area = centered_rect(78, 20, f.area());
+    let area = file_picker_area(f, app);
     let title_style = Style::default()
         .fg(theme.markdown.heading_2)
         .add_modifier(Modifier::BOLD);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -25,6 +25,7 @@ mod markdown_links;
 mod markdown_list_blocks;
 mod markdown_lists;
 mod markdown_tables;
+mod picker_width;
 mod render;
 mod theme;
 mod toc;

--- a/src/tests/picker_width.rs
+++ b/src/tests/picker_width.rs
@@ -1,0 +1,292 @@
+use crate::app::App;
+use crate::picker_width::{
+    parse_picker_width_spec, picker_width_raw, PickerWidthSpec, DEFAULT_PICKER_WIDTH,
+    PICKER_WIDTH_FLOOR_CELLS,
+};
+use crate::LeafConfig;
+use ratatui::text::Line;
+
+fn effective_cells(spec: PickerWidthSpec, area_width: u16) -> u16 {
+    picker_width_raw(spec, area_width).max(PICKER_WIDTH_FLOOR_CELLS)
+}
+
+#[test]
+fn parse_picker_width_percent() {
+    assert_eq!(
+        parse_picker_width_spec("1%"),
+        Some(PickerWidthSpec::Percent(1))
+    );
+    assert_eq!(
+        parse_picker_width_spec("50%"),
+        Some(PickerWidthSpec::Percent(50))
+    );
+    assert_eq!(
+        parse_picker_width_spec("78%"),
+        Some(PickerWidthSpec::Percent(78))
+    );
+    assert_eq!(
+        parse_picker_width_spec("100%"),
+        Some(PickerWidthSpec::Percent(100))
+    );
+}
+
+#[test]
+fn parse_picker_width_cells() {
+    assert_eq!(
+        parse_picker_width_spec("1cell"),
+        Some(PickerWidthSpec::Cells(1))
+    );
+    assert_eq!(
+        parse_picker_width_spec("78cells"),
+        Some(PickerWidthSpec::Cells(78))
+    );
+    assert_eq!(
+        parse_picker_width_spec("200cells"),
+        Some(PickerWidthSpec::Cells(200))
+    );
+}
+
+#[test]
+fn parse_picker_width_case_insensitive() {
+    assert_eq!(
+        parse_picker_width_spec("78Cells"),
+        Some(PickerWidthSpec::Cells(78))
+    );
+    assert_eq!(
+        parse_picker_width_spec("78CELLS"),
+        Some(PickerWidthSpec::Cells(78))
+    );
+    assert_eq!(
+        parse_picker_width_spec("50%"),
+        Some(PickerWidthSpec::Percent(50))
+    );
+}
+
+#[test]
+fn parse_picker_width_trims_whitespace() {
+    assert_eq!(
+        parse_picker_width_spec(" 78cells "),
+        Some(PickerWidthSpec::Cells(78))
+    );
+    assert_eq!(
+        parse_picker_width_spec("\t50%\n"),
+        Some(PickerWidthSpec::Percent(50))
+    );
+}
+
+#[test]
+fn parse_picker_width_rejects_internal_spaces() {
+    assert_eq!(parse_picker_width_spec("78 cells"), None);
+    assert_eq!(parse_picker_width_spec("50 %"), None);
+}
+
+#[test]
+fn parse_picker_width_invalid_returns_none() {
+    assert_eq!(parse_picker_width_spec("abc"), None);
+    assert_eq!(parse_picker_width_spec(""), None);
+    assert_eq!(parse_picker_width_spec("78"), None);
+    assert_eq!(parse_picker_width_spec("78px"), None);
+    assert_eq!(parse_picker_width_spec("0%"), None);
+    assert_eq!(parse_picker_width_spec("101%"), None);
+    assert_eq!(parse_picker_width_spec("0cells"), None);
+}
+
+#[test]
+fn parse_picker_width_deserialize_int_returns_none() {
+    let toml = r#"file-picker-width = 78"#;
+    let config: LeafConfig = toml::from_str(toml).unwrap();
+    assert_eq!(config.file_picker_width, None);
+}
+
+#[test]
+fn parse_picker_width_deserialize_bool_returns_none() {
+    let toml = r#"file-picker-width = true"#;
+    let config: LeafConfig = toml::from_str(toml).unwrap();
+    assert_eq!(config.file_picker_width, None);
+}
+
+#[test]
+fn parse_picker_width_deserialize_string_ok() {
+    let toml = r#"file-picker-width = "50%""#;
+    let config: LeafConfig = toml::from_str(toml).unwrap();
+    assert_eq!(config.file_picker_width, Some(PickerWidthSpec::Percent(50)));
+
+    let toml = r#"file-picker-width = "78cells""#;
+    let config: LeafConfig = toml::from_str(toml).unwrap();
+    assert_eq!(config.file_picker_width, Some(PickerWidthSpec::Cells(78)));
+}
+
+#[test]
+fn resolve_file_picker_width_defaults_when_none() {
+    // Note: env var is not set in test env by default.
+    let _guard = crate::tests::THEME_TEST_MUTEX.lock().unwrap();
+    std::env::remove_var("LEAF_FILE_PICKER_WIDTH");
+    let result = crate::resolve_file_picker_width(None);
+    assert_eq!(result, DEFAULT_PICKER_WIDTH);
+}
+
+#[test]
+fn resolve_file_picker_width_returns_config_when_valid() {
+    let _guard = crate::tests::THEME_TEST_MUTEX.lock().unwrap();
+    std::env::remove_var("LEAF_FILE_PICKER_WIDTH");
+    let result = crate::resolve_file_picker_width(Some(PickerWidthSpec::Percent(60)));
+    assert_eq!(result, PickerWidthSpec::Percent(60));
+}
+
+#[test]
+fn resolve_file_picker_width_env_overrides_config() {
+    let _guard = crate::tests::THEME_TEST_MUTEX.lock().unwrap();
+    std::env::set_var("LEAF_FILE_PICKER_WIDTH", "42cells");
+    let result = crate::resolve_file_picker_width(Some(PickerWidthSpec::Percent(60)));
+    std::env::remove_var("LEAF_FILE_PICKER_WIDTH");
+    assert_eq!(result, PickerWidthSpec::Cells(42));
+}
+
+#[test]
+fn resolve_file_picker_width_falls_back_when_env_invalid() {
+    let _guard = crate::tests::THEME_TEST_MUTEX.lock().unwrap();
+    std::env::set_var("LEAF_FILE_PICKER_WIDTH", "garbage");
+    let result = crate::resolve_file_picker_width(Some(PickerWidthSpec::Percent(60)));
+    std::env::remove_var("LEAF_FILE_PICKER_WIDTH");
+    assert_eq!(result, PickerWidthSpec::Percent(60));
+}
+
+#[test]
+fn picker_width_cells_percent_ceils_correctly() {
+    assert_eq!(effective_cells(PickerWidthSpec::Percent(80), 101), 81);
+    assert_eq!(effective_cells(PickerWidthSpec::Percent(50), 201), 101);
+}
+
+#[test]
+fn picker_width_cells_percent_applies_floor() {
+    assert_eq!(effective_cells(PickerWidthSpec::Percent(50), 100), 78);
+    assert_eq!(effective_cells(PickerWidthSpec::Percent(1), 100), 78);
+}
+
+#[test]
+fn picker_width_cells_percent_no_floor_when_above() {
+    assert_eq!(effective_cells(PickerWidthSpec::Percent(50), 200), 100);
+    assert_eq!(effective_cells(PickerWidthSpec::Percent(100), 200), 200);
+}
+
+#[test]
+fn picker_width_cells_cells_applies_floor() {
+    assert_eq!(effective_cells(PickerWidthSpec::Cells(30), 200), 78);
+    assert_eq!(effective_cells(PickerWidthSpec::Cells(1), 200), 78);
+}
+
+#[test]
+fn picker_width_cells_cells_pass_through_above_floor() {
+    assert_eq!(effective_cells(PickerWidthSpec::Cells(120), 200), 120);
+    assert_eq!(effective_cells(PickerWidthSpec::Cells(78), 200), 78);
+}
+
+#[test]
+fn picker_width_floor_constant_is_78() {
+    assert_eq!(PICKER_WIDTH_FLOOR_CELLS, 78);
+}
+
+fn make_app_with_spec(spec: PickerWidthSpec) -> App {
+    let mut app = App::new(
+        vec![Line::from("test")],
+        vec![],
+        "test".to_string(),
+        false,
+        false,
+        None,
+        None,
+    );
+    app.set_file_picker_width(spec);
+    app
+}
+
+#[test]
+fn floor_state_triggers_warning_on_transition_below() {
+    let mut app = make_app_with_spec(PickerWidthSpec::Percent(50));
+    assert!(!app.picker_width_floor_active);
+    app.refresh_picker_width_floor(100);
+    assert!(app.picker_width_floor_active);
+    assert!(app.config_flash().is_some());
+}
+
+#[test]
+fn floor_state_resets_silently_on_transition_above() {
+    let mut app = make_app_with_spec(PickerWidthSpec::Percent(50));
+    app.refresh_picker_width_floor(100);
+    assert!(app.picker_width_floor_active);
+    app.refresh_picker_width_floor(200);
+    assert!(!app.picker_width_floor_active);
+}
+
+#[test]
+fn floor_state_re_triggers_after_reset() {
+    let mut app = make_app_with_spec(PickerWidthSpec::Percent(50));
+    app.refresh_picker_width_floor(100);
+    assert!(app.picker_width_floor_active);
+    app.refresh_picker_width_floor(200);
+    assert!(!app.picker_width_floor_active);
+    app.clear_config_flash();
+    app.refresh_picker_width_floor(100);
+    assert!(app.picker_width_floor_active);
+    assert!(app.config_flash().is_some());
+}
+
+#[test]
+fn floor_state_triggers_for_cells_spec_below_floor() {
+    let mut app = make_app_with_spec(PickerWidthSpec::Cells(30));
+    app.refresh_picker_width_floor(100);
+    assert!(app.picker_width_floor_active);
+}
+
+#[test]
+fn floor_state_no_trigger_for_cells_spec_above_floor() {
+    let mut app = make_app_with_spec(PickerWidthSpec::Cells(120));
+    app.refresh_picker_width_floor(200);
+    assert!(!app.picker_width_floor_active);
+}
+
+#[test]
+fn floor_state_no_trigger_when_percent_produces_above_floor() {
+    let mut app = make_app_with_spec(PickerWidthSpec::Percent(50));
+    app.refresh_picker_width_floor(200);
+    assert!(!app.picker_width_floor_active);
+}
+
+#[test]
+fn floor_state_no_trigger_when_clamp_equalizes() {
+    let mut app = make_app_with_spec(PickerWidthSpec::Cells(30));
+    // On terminal 30: cap=28, min(30,28)=28, min(78,28)=28 → equal, silence.
+    app.refresh_picker_width_floor(30);
+    assert!(!app.picker_width_floor_active);
+}
+
+#[test]
+fn floor_state_cycle_triggers_on_return_to_visible_effect() {
+    let mut app = make_app_with_spec(PickerWidthSpec::Cells(30));
+    app.refresh_picker_width_floor(100);
+    assert!(app.picker_width_floor_active);
+    app.refresh_picker_width_floor(30);
+    assert!(!app.picker_width_floor_active);
+    app.clear_config_flash();
+    app.refresh_picker_width_floor(100);
+    assert!(app.picker_width_floor_active);
+    assert!(app.config_flash().is_some());
+}
+
+#[test]
+fn floor_state_reset_on_close_file_picker() {
+    let mut app = make_app_with_spec(PickerWidthSpec::Cells(30));
+    app.refresh_picker_width_floor(100);
+    assert!(app.picker_width_floor_active);
+    app.close_file_picker();
+    assert!(!app.picker_width_floor_active);
+}
+
+#[test]
+fn floor_state_reset_on_cancel_picker_loading() {
+    let mut app = make_app_with_spec(PickerWidthSpec::Cells(30));
+    app.refresh_picker_width_floor(100);
+    assert!(app.picker_width_floor_active);
+    app.cancel_picker_loading();
+    assert!(!app.picker_width_floor_active);
+}


### PR DESCRIPTION
Width of the file picker (fuzzy + file browser)
Accepted formats:
* "NN%":     percent of terminal width, converted to cells (ceil)
* "NNcells": absolute number of terminal cells

The final width is always capped by (terminal_width - 2) cells.

Priority: LEAF_FILE_PICKER_WIDTH > this setting > default ("78cells")
Minimum: 78 cells. Applies to both formats.
Default: "78cells"
file-picker-width = "78cells"