### PR TITLE
feat: open editor in zellij pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ editor = 'code -g {$path}:{$line}'
 
 Without `{$line}`, the editor opens at the top of the file.
 
+Inside a **zellij** session, `Ctrl+E` opens the editor in a pane placed over **leaf**'s own pane (`zellij action edit --in-place`) instead of a new tab of the host terminal. Closing the pane brings **leaf** back.
+
+On this path the editor is the one zellij is configured with (`scrollback_editor`, else `$EDITOR`), so the `editor` setting applies to GUI editors only. The visible line is always passed, so `{$line}` is not needed.
+
 ## Extra Files
 
 Non-Markdown files can be listed in the file picker by adding their extensions to `config.toml`:

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -278,6 +278,10 @@ fn platform_fallback_editor() -> &'static str {
     }
 }
 
+fn is_zellij() -> bool {
+    std::env::var_os("ZELLIJ").is_some()
+}
+
 fn is_wsl() -> bool {
     static CACHED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *CACHED.get_or_init(|| {
@@ -333,13 +337,34 @@ pub(crate) fn format_editor_tab_title(file: &Path, tab_title_length: Option<i32>
     format!("{EDITOR_TAB_PREFIX}{display}")
 }
 
+// Inside zellij the host emulator is the wrong target: its new tab would land
+// outside the session. Open a zellij pane in place of leaf's own pane instead.
+// The editor is zellij's (`scrollback_editor`, else $EDITOR), so leaf's editor
+// command is not used here -- only the file and the visible line.
+fn zellij_edit_command(file: &Path, line: usize) -> LaunchStrategy {
+    let mut cmd = Command::new("zellij");
+    cmd.arg("action")
+        .arg("edit")
+        .arg("--in-place")
+        .arg("--line-number")
+        .arg(line.max(1).to_string())
+        .arg(file);
+    LaunchStrategy::RunAndCheck(cmd)
+}
+
 pub(crate) fn try_new_tab_command(
     editor: &str,
     file: &Path,
+    line: usize,
     emulator: &TerminalEmulator,
     wsl: bool,
+    zellij: bool,
     tab_title_length: Option<i32>,
 ) -> Option<LaunchStrategy> {
+    if zellij {
+        return Some(zellij_edit_command(file, line));
+    }
+
     let (bin, args) = split_editor_cmd(editor);
     let file_str = file.display().to_string();
     let title = format_editor_tab_title(file, tab_title_length);
@@ -423,6 +448,7 @@ pub(crate) enum EditorResult {
 pub(crate) fn open_in_editor(
     editor: &str,
     file: &Path,
+    line: usize,
     kind: EditorKind,
     emulator: &TerminalEmulator,
     tab_title_length: Option<i32>,
@@ -438,9 +464,17 @@ pub(crate) fn open_in_editor(
             Ok(EditorResult::Opened)
         }
         EditorKind::Terminal => {
-            if try_new_tab_command(editor, file, emulator, is_wsl(), tab_title_length)
-                .map(LaunchStrategy::run)
-                .unwrap_or(false)
+            if try_new_tab_command(
+                editor,
+                file,
+                line,
+                emulator,
+                is_wsl(),
+                is_zellij(),
+                tab_title_length,
+            )
+            .map(LaunchStrategy::run)
+            .unwrap_or(false)
             {
                 return Ok(EditorResult::Opened);
             }

--- a/src/runtime/mouse.rs
+++ b/src/runtime/mouse.rs
@@ -303,7 +303,15 @@ fn try_open_editor(
     themes: &ThemeSet,
 ) -> Result<Option<EditorFlash>> {
     let kind = classify(editor_cmd);
-    match open_in_editor(editor_cmd, filepath, kind, emulator, app.tab_title_length()) {
+    let visible_source_line = app.source_line_at(app.scroll());
+    match open_in_editor(
+        editor_cmd,
+        filepath,
+        visible_source_line,
+        kind,
+        emulator,
+        app.tab_title_length(),
+    ) {
         Ok(EditorResult::Opened) => {
             let name = editor::binary_name(editor_cmd).to_string();
             Ok(Some(EditorFlash::Opened(name)))

--- a/src/tests/editor.rs
+++ b/src/tests/editor.rs
@@ -164,7 +164,8 @@ fn classify_windows_path_with_spaces() {
 
 fn mac_tab_script(editor: &str, file: &str, term_program: &str) -> String {
     let emulator = TerminalEmulator::MacTerminal(term_program.to_string());
-    let strategy = try_new_tab_command(editor, Path::new(file), &emulator, false, None).unwrap();
+    let strategy =
+        try_new_tab_command(editor, Path::new(file), 1, &emulator, false, false, None).unwrap();
     let cmd = match strategy {
         LaunchStrategy::SpawnAndAssume(cmd) => cmd,
         LaunchStrategy::RunAndCheck(_) => panic!("expected SpawnAndAssume for MacTerminal"),
@@ -176,7 +177,15 @@ fn mac_tab_script(editor: &str, file: &str, term_program: &str) -> String {
 #[test]
 fn try_new_tab_command_windows_terminal_wsl_linux_editor_returns_none() {
     let emulator = TerminalEmulator::WindowsTerminal;
-    let strategy = try_new_tab_command("nano", Path::new("/tmp/test.md"), &emulator, true, None);
+    let strategy = try_new_tab_command(
+        "nano",
+        Path::new("/tmp/test.md"),
+        1,
+        &emulator,
+        true,
+        false,
+        None,
+    );
     assert!(strategy.is_none());
 }
 
@@ -186,8 +195,10 @@ fn try_new_tab_command_windows_terminal_wsl_windows_editor_returns_spawn() {
     let strategy = try_new_tab_command(
         "notepad.exe",
         Path::new("/tmp/test.md"),
+        1,
         &emulator,
         true,
+        false,
         None,
     )
     .unwrap();
@@ -197,39 +208,146 @@ fn try_new_tab_command_windows_terminal_wsl_windows_editor_returns_spawn() {
 #[test]
 fn try_new_tab_command_windows_terminal_non_wsl_returns_spawn() {
     let emulator = TerminalEmulator::WindowsTerminal;
-    let strategy =
-        try_new_tab_command("nano", Path::new("/tmp/test.md"), &emulator, false, None).unwrap();
+    let strategy = try_new_tab_command(
+        "nano",
+        Path::new("/tmp/test.md"),
+        1,
+        &emulator,
+        false,
+        false,
+        None,
+    )
+    .unwrap();
     assert!(matches!(strategy, LaunchStrategy::SpawnAndAssume(_)));
 }
 
 #[test]
 fn try_new_tab_command_kitty_returns_run_and_check() {
     let emulator = TerminalEmulator::Kitty;
-    let strategy =
-        try_new_tab_command("nano", Path::new("/tmp/test.md"), &emulator, false, None).unwrap();
+    let strategy = try_new_tab_command(
+        "nano",
+        Path::new("/tmp/test.md"),
+        1,
+        &emulator,
+        false,
+        false,
+        None,
+    )
+    .unwrap();
     assert!(matches!(strategy, LaunchStrategy::RunAndCheck(_)));
 }
 
 #[test]
 fn try_new_tab_command_gnome_returns_spawn() {
     let emulator = TerminalEmulator::GnomeTerminal;
-    let strategy =
-        try_new_tab_command("vim", Path::new("/tmp/test.md"), &emulator, false, None).unwrap();
+    let strategy = try_new_tab_command(
+        "vim",
+        Path::new("/tmp/test.md"),
+        1,
+        &emulator,
+        false,
+        false,
+        None,
+    )
+    .unwrap();
     assert!(matches!(strategy, LaunchStrategy::SpawnAndAssume(_)));
 }
 
 #[test]
 fn try_new_tab_command_termux_returns_none() {
     let emulator = TerminalEmulator::Termux;
-    let strategy = try_new_tab_command("nano", Path::new("/tmp/test.md"), &emulator, false, None);
+    let strategy = try_new_tab_command(
+        "nano",
+        Path::new("/tmp/test.md"),
+        1,
+        &emulator,
+        false,
+        false,
+        None,
+    );
     assert!(strategy.is_none());
 }
 
 #[test]
 fn try_new_tab_command_unknown_returns_none() {
     let emulator = TerminalEmulator::Unknown;
-    let strategy = try_new_tab_command("nano", Path::new("/tmp/test.md"), &emulator, false, None);
+    let strategy = try_new_tab_command(
+        "nano",
+        Path::new("/tmp/test.md"),
+        1,
+        &emulator,
+        false,
+        false,
+        None,
+    );
     assert!(strategy.is_none());
+}
+
+fn zellij_command(
+    editor: &str,
+    file: &str,
+    line: usize,
+    emulator: &TerminalEmulator,
+) -> Vec<String> {
+    let strategy =
+        try_new_tab_command(editor, Path::new(file), line, emulator, false, true, None).unwrap();
+    let cmd = match strategy {
+        LaunchStrategy::RunAndCheck(cmd) => cmd,
+        LaunchStrategy::SpawnAndAssume(_) => panic!("expected RunAndCheck for zellij"),
+    };
+    let mut out = vec![cmd.get_program().to_string_lossy().into_owned()];
+    out.extend(cmd.get_args().map(|a| a.to_string_lossy().into_owned()));
+    out
+}
+
+#[test]
+fn try_new_tab_command_zellij_edits_in_place() {
+    let args = zellij_command("nano", "/tmp/test.md", 1, &TerminalEmulator::Unknown);
+    assert_eq!(
+        args,
+        vec![
+            "zellij",
+            "action",
+            "edit",
+            "--in-place",
+            "--line-number",
+            "1",
+            "/tmp/test.md"
+        ]
+    );
+}
+
+#[test]
+fn try_new_tab_command_zellij_wins_over_host_emulator() {
+    for emulator in [
+        TerminalEmulator::MacTerminal("iTerm.app".into()),
+        TerminalEmulator::Kitty,
+        TerminalEmulator::GnomeTerminal,
+        TerminalEmulator::Unknown,
+    ] {
+        let args = zellij_command("nano", "/tmp/test.md", 1, &emulator);
+        assert_eq!(args[0], "zellij", "host emulator won for {emulator:?}");
+    }
+}
+
+#[test]
+fn try_new_tab_command_zellij_passes_visible_line() {
+    let args = zellij_command("hx", "/tmp/test.md", 42, &TerminalEmulator::Unknown);
+    let idx = args
+        .iter()
+        .position(|a| a == "--line-number")
+        .expect("--line-number arg missing");
+    assert_eq!(args[idx + 1], "42");
+}
+
+#[test]
+fn try_new_tab_command_zellij_clamps_zero_line() {
+    let args = zellij_command("hx", "/tmp/test.md", 0, &TerminalEmulator::Unknown);
+    let idx = args
+        .iter()
+        .position(|a| a == "--line-number")
+        .expect("--line-number arg missing");
+    assert_eq!(args[idx + 1], "1");
 }
 
 #[test]
@@ -460,7 +578,9 @@ fn kitty_tab_title_uses_filename() {
     let strategy = try_new_tab_command(
         "nano",
         Path::new("/tmp/readme.md"),
+        1,
         &TerminalEmulator::Kitty,
+        false,
         false,
         None,
     )
@@ -485,7 +605,9 @@ fn gnome_tab_title_uses_filename() {
     let strategy = try_new_tab_command(
         "vim",
         Path::new("/tmp/notes.md"),
+        1,
         &TerminalEmulator::GnomeTerminal,
+        false,
         false,
         None,
     )
@@ -509,8 +631,10 @@ fn windows_terminal_tab_title_uses_filename() {
     let strategy = try_new_tab_command(
         "notepad.exe",
         Path::new("/tmp/notes.md"),
+        1,
         &TerminalEmulator::WindowsTerminal,
         true,
+        false,
         None,
     )
     .unwrap();


### PR DESCRIPTION
## What

Inside a zellij session, `Ctrl+E` now opens the editor in a zellij pane placed over **leaf**'s own pane (`zellij action edit --in-place --line-number <line> <file>`) instead of a new tab of the host terminal.

- `is_zellij()` — detects the `ZELLIJ` env var, alongside the existing `is_wsl()`.
- `zellij_edit_command()` — builds that command as a `RunAndCheck` strategy.
- `try_new_tab_command()` gains `line: usize` and `zellij: bool`; when `zellij` is set it short-circuits ahead of the emulator match, so zellij wins over kitty / gnome-terminal / Windows Terminal / iTerm2 / Terminal.app.
- `open_in_editor()` forwards the visible source line (`app.source_line_at(app.scroll())`).

## Why

`detect_terminal_emulator()` reads the host terminal's environment (`TERM_PROGRAM`, `KITTY_PID`, …), and those variables are still set inside a zellij session. So **leaf** opened its editor tab in the *host* terminal — outside the multiplexer, in a window the user had deliberately left behind.

Two deliberate choices:

- **zellij is an injected `bool`, not a new `TerminalEmulator` variant.** `detect_terminal_emulator()` also feeds `selection_modifier_label()`, and the host terminal still owns text selection under zellij. A new variant would have flipped the help-popup hint from `option+drag` to `shift+drag` on iTerm2. Passing the flag the way `wsl` already is keeps that hint correct and keeps the branch unit-testable.
- **`RunAndCheck`, not `SpawnAndAssume`.** The zellij CLI exits non-zero when it cannot reach the session, so **leaf** falls through to `NeedsSameTerminal` and edits inline rather than appearing to do nothing.

## Alternative: `zellij run` instead of `zellij action edit`

Happy to ship this instead if you prefer it — it is a smaller patch than the one above, and I have no strong preference.

`zellij action edit` delegates to zellij's own editor, which is where every trade-off below comes from. `zellij run` takes a command, so **leaf**'s configured editor can be launched directly:

```
zellij run --in-place --close-on-exit --name "<editor tab title>" -- nano +42 /path/file.md
```

- The `editor` setting and its `{$line}` / `{$path}` placeholders apply on this path like they do everywhere else — the string passed to `try_new_tab_command()` is already expanded.
- `line: usize` is then no longer needed at all: it disappears from `zellij_edit_command()`, `try_new_tab_command()` and `open_in_editor()`, along with the second `source_line_at()` call in `runtime/mouse.rs`.
- `--name` can reuse `format_editor_tab_title()`, so `tab-title-length` applies here too. The current patch silently ignores it.
- `EditorFlash::Opened` becomes truthful, since the launched binary is the configured one.

The reason it is not the default here: it changes which editor opens for anyone who has set zellij's `scrollback_editor`. That felt like the maintainers' call rather than mine. Flags verified against zellij 0.44.0 (`run -i/--in-place`, `-n/--name`, `-c/--close-on-exit`).

## Trade-offs of the approach in this PR

- `zellij action edit` uses zellij's own editor (`scrollback_editor`, else `$EDITOR`), so the `editor` setting and its `{$line}` / `{$path}` placeholders do not apply on this path. Forwarding `--line-number` is what keeps line positioning working there without a placeholder.
- GUI editors (`code`, `zed`, …) are untouched — they never went through the tab path.
- No opt-out: any **leaf** running inside zellij gets the pane. Happy to gate it behind a config key if you would prefer that.
- `EditorFlash::Opened` still reports **leaf**'s configured editor name, which may differ from what zellij launched. With `--in-place` **leaf**'s pane is suspended while editing, so the flash is effectively never seen; left alone rather than widening `EditorResult` for an invisible string.

## How tested

- `cargo test` — 417 passed, including 4 new tests: the in-place command shape, zellij winning over each host emulator, the visible line being forwarded, and line `0` clamped to `1`.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.
- `cargo build --release` — ok.
- README updated (`Open in Editor` section).
- Manually verified on a live, attached zellij 0.44.0 session: `Ctrl+E` opens the editor in place of **leaf**'s pane as described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
