### PR TITLE
fix: make Mermaid rendering responsive

### DIFF
--- a/demo.md
+++ b/demo.md
@@ -1,0 +1,85 @@
+# Responsive Mermaid rendering
+
+At narrow widths, Leaf reflows oversized horizontal flowcharts and uses stacked class cards when
+the original two-dimensional class layout cannot fit without wrapping.
+
+## Horizontal flowchart
+
+```mermaid
+flowchart LR
+    File[Path]
+    Service[SourceService.upload_file]
+    Capability{SOURCE_UPLOAD supported?}
+    Workflow[Selected backend owns<br/>register + transfer + reconcile]
+    Receipt[Phase-aware private<br/>upload receipt]
+    Stream[Backend-specific Scotty<br/>start + upload/finalize]
+    Reconcile[Same-backend source read]
+    Result[Source or outcome-unknown<br/>error]
+
+    File --> Service --> Capability
+    Capability -->|no| Unsupported[UnsupportedOperationError<br/>before I/O]
+    Capability -->|yes| Workflow --> Receipt --> Stream --> Reconcile --> Result
+```
+
+## Class diagram
+
+```mermaid
+classDiagram
+    class Client {
+        +BackendCapabilities capabilities
+        +StudioCatalogService studio
+        +AudioOverviewService audio_overviews
+        +from_profile()
+        +close()
+    }
+    class BackendAdapter {
+        <<Protocol>>
+        +invoke(OperationDef, input, deadline)
+        +stream(OperationDef, input, deadline)
+        +close()
+    }
+    class MobileBackend {
+        -GrpcTransport transport
+        -MobileCodec codec
+        +invoke()
+        +stream()
+    }
+    class WebBackend {
+        -RpcTransport transport
+        -WebCodec codec
+        +invoke()
+        +stream()
+    }
+    class CatalogService {
+        -backend
+        +list()
+        +get()
+    }
+    class QuizService {
+        -backend
+        +create_quiz()
+        +wait_quiz()
+    }
+    class ResearchService {
+        -backend
+        +start_deep()
+        +import_results()
+    }
+    class ArtifactSummary {
+        +artifact_id
+        +kind
+        +status
+    }
+
+    Client *-- BackendAdapter
+    Client *-- CatalogService
+    Client *-- QuizService
+    Client *-- ResearchService
+    BackendAdapter <|.. MobileBackend
+    BackendAdapter <|.. WebBackend
+    CatalogService --> BackendAdapter
+    CatalogService --> ArtifactSummary
+    QuizService --> BackendAdapter
+    QuizService --> ArtifactSummary
+    ResearchService --> BackendAdapter
+```

--- a/src/markdown/blocks.rs
+++ b/src/markdown/blocks.rs
@@ -334,10 +334,6 @@ pub(super) fn push_special_block_lines<F: Fn(&str) -> Vec<Span<'static>>>(
     item_stack: &mut [ItemState],
     ctx: SpecialBlockCtx<'_, F>,
 ) -> BlockLayout {
-    let label = ctx.label;
-    let content_lines = ctx.content_lines;
-    let show_line_numbers = ctx.show_line_numbers;
-    let center = ctx.center;
     let prefix = if !item_stack.is_empty() {
         list_item_prefix(blockquote_depth, list_stack, item_stack, theme, None)
     } else if blockquote_depth > 0 {
@@ -345,6 +341,20 @@ pub(super) fn push_special_block_lines<F: Fn(&str) -> Vec<Span<'static>>>(
     } else {
         Vec::new()
     };
+    push_special_block_lines_with_prefix(lines, render_width, theme, prefix, ctx)
+}
+
+fn push_special_block_lines_with_prefix<F: Fn(&str) -> Vec<Span<'static>>>(
+    lines: &mut Vec<Line<'static>>,
+    render_width: usize,
+    theme: &MarkdownTheme,
+    prefix: Vec<Span<'static>>,
+    ctx: SpecialBlockCtx<'_, F>,
+) -> BlockLayout {
+    let label = ctx.label;
+    let content_lines = ctx.content_lines;
+    let show_line_numbers = ctx.show_line_numbers;
+    let center = ctx.center;
     let prefix_width: usize = prefix
         .iter()
         .map(|span| display_width(span.content.as_ref()))
@@ -500,7 +510,26 @@ pub(super) fn push_mermaid_block_lines(
     ctx: EmbeddedBlockCtx<'_>,
     item_stack: &mut [ItemState],
 ) -> BlockLayout {
-    let rendered = mermaid::render(content);
+    let prefix = if !item_stack.is_empty() {
+        list_item_prefix(
+            ctx.blockquote_depth,
+            ctx.list_stack,
+            item_stack,
+            ctx.theme,
+            None,
+        )
+    } else if ctx.blockquote_depth > 0 {
+        block_prefix(ctx.blockquote_depth, ctx.theme, None)
+    } else {
+        Vec::new()
+    };
+    let prefix_width: usize = prefix
+        .iter()
+        .map(|span| display_width(span.content.as_ref()))
+        .sum();
+    // The frame, gutter, and right-side padding consume four columns.
+    let max_diagram_width = ctx.render_width.saturating_sub(prefix_width + 4);
+    let rendered = mermaid::render(content, max_diagram_width);
     let use_rendered = rendered.is_some();
     let content_lines: Vec<&str> = if let Some(ref r) = rendered {
         r.lines().collect()
@@ -508,13 +537,11 @@ pub(super) fn push_mermaid_block_lines(
         content.lines().collect()
     };
     let content_style = Style::default().fg(ctx.theme.mermaid_block_fg);
-    push_special_block_lines(
+    push_special_block_lines_with_prefix(
         lines,
         ctx.render_width,
         ctx.theme,
-        ctx.blockquote_depth,
-        ctx.list_stack,
-        item_stack,
+        prefix,
         SpecialBlockCtx {
             label: "mermaid",
             content_lines: &content_lines,

--- a/src/markdown/mermaid.rs
+++ b/src/markdown/mermaid.rs
@@ -3,15 +3,281 @@ use mmdflux::{render_diagram, OutputFormat, RenderConfig};
 use ratatui::{style::Style, text::Span};
 use std::fmt::Write;
 
-pub(crate) fn render(content: &str) -> Option<String> {
+use super::width::{display_width, truncate_display_width};
+
+pub(crate) fn render(content: &str, max_width: usize) -> Option<String> {
     let trimmed = content.trim();
     if trimmed.is_empty() {
         return None;
     }
     if trimmed.starts_with("pie") {
-        return render_pie(trimmed);
+        return render_pie(trimmed).filter(|rendered| fits_width(rendered, max_width));
     }
-    render_diagram(trimmed, OutputFormat::Text, &RenderConfig::default()).ok()
+
+    let rendered = render_diagram(trimmed, OutputFormat::Text, &RenderConfig::default()).ok();
+    if rendered
+        .as_deref()
+        .is_some_and(|rendered| fits_width(rendered, max_width))
+    {
+        return rendered;
+    }
+
+    if trimmed.starts_with("classDiagram") {
+        // Only substitute the compact renderer for a valid diagram that is too
+        // wide. Parse/render failures should retain the source fallback.
+        rendered.as_ref()?;
+        if let Some(horizontal) = use_horizontal_class_direction(trimmed) {
+            if let Ok(rendered) =
+                render_diagram(&horizontal, OutputFormat::Text, &RenderConfig::default())
+            {
+                if fits_width(&rendered, max_width) {
+                    return Some(rendered);
+                }
+            }
+        }
+        return render_vertical_class_diagram(trimmed, max_width);
+    }
+
+    let vertical = use_vertical_direction(trimmed)?;
+    render_diagram(&vertical, OutputFormat::Text, &RenderConfig::default())
+        .ok()
+        .filter(|rendered| fits_width(rendered, max_width))
+}
+
+fn fits_width(rendered: &str, max_width: usize) -> bool {
+    max_width > 0
+        && rendered
+            .lines()
+            .all(|line| display_width(line) <= max_width)
+}
+
+fn use_vertical_direction(content: &str) -> Option<String> {
+    let mut lines: Vec<String> = content.lines().map(str::to_string).collect();
+
+    for line in &mut lines {
+        let leading_width = line.len() - line.trim_start().len();
+        let trimmed = line.trim_start();
+        let Some(keyword_end) = trimmed.find(char::is_whitespace) else {
+            continue;
+        };
+        if !matches!(&trimmed[..keyword_end], "flowchart" | "graph") {
+            continue;
+        }
+
+        let after_keyword = &trimmed[keyword_end..];
+        let whitespace_width = after_keyword.len() - after_keyword.trim_start().len();
+        let direction_start = leading_width + keyword_end + whitespace_width;
+        let direction = line[direction_start..]
+            .split_whitespace()
+            .next()?
+            .trim_end_matches(';');
+        if !matches!(direction, "LR" | "RL") {
+            return None;
+        }
+
+        line.replace_range(direction_start..direction_start + direction.len(), "TD");
+        return Some(lines.join("\n"));
+    }
+
+    None
+}
+
+fn use_horizontal_class_direction(content: &str) -> Option<String> {
+    let mut lines: Vec<String> = content.lines().map(str::to_string).collect();
+    let header = lines
+        .iter()
+        .position(|line| line.trim() == "classDiagram")?;
+
+    for line in lines.iter_mut().skip(header + 1) {
+        let trimmed = line.trim();
+        let Some(direction) = trimmed.strip_prefix("direction ") else {
+            continue;
+        };
+        if matches!(direction.trim_end_matches(';'), "LR" | "RL") {
+            return None;
+        }
+        if !matches!(direction.trim_end_matches(';'), "TB" | "TD" | "BT") {
+            continue;
+        }
+
+        let direction_start = line.find(direction)?;
+        let direction_len = direction.trim_end_matches(';').len();
+        line.replace_range(direction_start..direction_start + direction_len, "LR");
+        return Some(lines.join("\n"));
+    }
+
+    lines.insert(header + 1, "    direction LR".to_string());
+    Some(lines.join("\n"))
+}
+
+#[derive(Default)]
+struct ClassBlock {
+    name: String,
+    members: Vec<String>,
+}
+
+fn render_vertical_class_diagram(content: &str, max_width: usize) -> Option<String> {
+    if max_width < 12 {
+        return None;
+    }
+
+    let mut classes = Vec::new();
+    let mut relationships = Vec::new();
+    let mut current: Option<ClassBlock> = None;
+
+    for source_line in content.lines().skip(1) {
+        let line = source_line.trim();
+        if line.is_empty() || line.starts_with("direction ") {
+            continue;
+        }
+
+        if let Some(class) = current.as_mut() {
+            if line == "}" {
+                classes.push(current.take().unwrap());
+            } else {
+                class.members.push(line.to_string());
+            }
+            continue;
+        }
+
+        if let Some(declaration) = line.strip_prefix("class ") {
+            if let Some(name) = declaration.strip_suffix('{') {
+                current = Some(ClassBlock {
+                    name: name.trim().to_string(),
+                    members: Vec::new(),
+                });
+            } else {
+                classes.push(ClassBlock {
+                    name: declaration.trim().to_string(),
+                    members: Vec::new(),
+                });
+            }
+            continue;
+        }
+
+        if looks_like_class_relationship(line) {
+            relationships.push(line.to_string());
+        }
+    }
+    if let Some(class) = current {
+        classes.push(class);
+    }
+    if classes.is_empty() {
+        return None;
+    }
+
+    let widest_class_line = classes
+        .iter()
+        .flat_map(|class| std::iter::once(&class.name).chain(class.members.iter()))
+        .map(|line| display_width(line))
+        .max()
+        .unwrap_or(0);
+    let card_width = (widest_class_line + 4).clamp(12, max_width);
+    let inner_width = card_width - 2;
+    let text_width = inner_width.saturating_sub(2).max(1);
+    let border = "─".repeat(inner_width);
+    let mut out = String::new();
+
+    for (index, class) in classes.iter().enumerate() {
+        if index > 0 {
+            out.push('\n');
+        }
+        let _ = writeln!(out, "┌{border}┐");
+        push_card_text(&mut out, &class.name, text_width, inner_width);
+        if !class.members.is_empty() {
+            let _ = writeln!(out, "├{border}┤");
+            for member in &class.members {
+                push_card_text(&mut out, member, text_width, inner_width);
+            }
+        }
+        let _ = writeln!(out, "└{border}┘");
+    }
+
+    if !relationships.is_empty() {
+        out.push('\n');
+        let heading = truncate_display_width("Relationships", max_width);
+        let _ = writeln!(out, "{heading}");
+        let _ = writeln!(out, "{}", "─".repeat(display_width(&heading)));
+        for relationship in relationships {
+            push_prefixed_wrapped_text(&mut out, &relationship, "• ", "  ", max_width);
+        }
+    }
+
+    Some(out.trim_end().to_string())
+}
+
+fn looks_like_class_relationship(line: &str) -> bool {
+    line.split_whitespace().any(|part| {
+        part.contains("--") || part.contains("..") || part.contains("<|") || part.contains("|>")
+    })
+}
+
+fn push_card_text(out: &mut String, text: &str, text_width: usize, inner_width: usize) {
+    for line in wrap_display_text(text, text_width) {
+        let padding = inner_width.saturating_sub(display_width(&line) + 1);
+        let _ = writeln!(out, "│ {line}{}│", " ".repeat(padding));
+    }
+}
+
+fn push_prefixed_wrapped_text(
+    out: &mut String,
+    text: &str,
+    first_prefix: &str,
+    continuation_prefix: &str,
+    max_width: usize,
+) {
+    let prefix_width = display_width(first_prefix).max(display_width(continuation_prefix));
+    let line_width = max_width.saturating_sub(prefix_width).max(1);
+    for (index, line) in wrap_display_text(text, line_width).into_iter().enumerate() {
+        let prefix = if index == 0 {
+            first_prefix
+        } else {
+            continuation_prefix
+        };
+        let _ = writeln!(out, "{prefix}{line}");
+    }
+}
+
+fn wrap_display_text(text: &str, max_width: usize) -> Vec<String> {
+    if text.is_empty() {
+        return vec![String::new()];
+    }
+
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for word in text.split_whitespace() {
+        let separator = usize::from(!current.is_empty());
+        if display_width(&current) + separator + display_width(word) <= max_width {
+            if separator > 0 {
+                current.push(' ');
+            }
+            current.push_str(word);
+            continue;
+        }
+        if !current.is_empty() {
+            lines.push(std::mem::take(&mut current));
+        }
+
+        let mut remainder = word;
+        while display_width(remainder) > max_width {
+            let split = remainder
+                .char_indices()
+                .take_while(|(index, ch)| {
+                    display_width(&remainder[..*index]) + display_width(&ch.to_string())
+                        <= max_width
+                })
+                .map(|(index, ch)| index + ch.len_utf8())
+                .last()
+                .unwrap_or_else(|| remainder.chars().next().unwrap().len_utf8());
+            lines.push(remainder[..split].to_string());
+            remainder = &remainder[split..];
+        }
+        current.push_str(remainder);
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    lines
 }
 
 fn render_pie(content: &str) -> Option<String> {

--- a/src/tests/markdown_embedded.rs
+++ b/src/tests/markdown_embedded.rs
@@ -1,5 +1,5 @@
 use super::{rendered_non_empty_lines, test_assets, test_md_theme};
-use crate::markdown::parse_markdown;
+use crate::markdown::{parse_markdown, parse_markdown_with_width};
 use crate::*;
 
 #[test]
@@ -119,6 +119,74 @@ fn mermaid_block_renders_in_framed_block() {
     assert!(
         rendered.iter().any(|line| line.contains("└")),
         "expected mermaid block footer"
+    );
+}
+
+#[test]
+fn oversized_horizontal_mermaid_reflows_vertically() {
+    let (ss, theme) = test_assets();
+    let src = "```mermaid\nflowchart LR\n  A[Collect request] --> B[Validate request] --> C[Store response]\n```\n";
+    let (lines, _, _, _) =
+        parse_markdown_with_width(src, &ss, &theme, 50, &test_md_theme(), false, true).into();
+    let rendered = rendered_non_empty_lines(&lines);
+
+    assert!(
+        rendered.iter().all(|line| display_width(line) <= 50),
+        "responsive mermaid render should stay within the viewport: {rendered:?}"
+    );
+    assert!(
+        rendered.iter().all(|line| !line.contains("│1│")),
+        "an LR flowchart that fits vertically should remain rendered, not fall back to source"
+    );
+    assert!(
+        rendered.iter().any(|line| line.contains("Collect request"))
+            && rendered.iter().any(|line| line.contains("Store response")),
+        "responsive render should preserve node labels"
+    );
+}
+
+#[test]
+fn oversized_mermaid_falls_back_instead_of_wrapping_diagram_rows() {
+    let (ss, theme) = test_assets();
+    let src = format!(
+        "```mermaid\nflowchart TD\n  A[{}]\n```\n",
+        "oversized ".repeat(10)
+    );
+    let (lines, _, _, _) =
+        parse_markdown_with_width(&src, &ss, &theme, 50, &test_md_theme(), false, true).into();
+    let rendered = rendered_non_empty_lines(&lines);
+
+    assert!(
+        rendered.iter().any(|line| line.contains("│1│")),
+        "a diagram that cannot fit in either orientation should show readable source"
+    );
+    assert!(
+        rendered.iter().any(|line| line.contains("flowchart TD")),
+        "fallback should retain the Mermaid source"
+    );
+}
+
+#[test]
+fn oversized_class_diagram_uses_vertical_cards() {
+    let (ss, theme) = test_assets();
+    let src = "```mermaid\nclassDiagram\n  class Client {\n    +BackendCapabilities capabilities\n    +from_profile()\n  }\n  class BackendAdapter {\n    <<Protocol>>\n    +invoke(OperationDef, input, deadline)\n  }\n  Client *-- BackendAdapter\n```\n";
+    let (lines, _, _, _) =
+        parse_markdown_with_width(src, &ss, &theme, 32, &test_md_theme(), false, true).into();
+    let rendered = rendered_non_empty_lines(&lines);
+
+    assert!(
+        rendered.iter().all(|line| display_width(line) <= 32),
+        "vertical class cards should stay within the viewport: {rendered:?}"
+    );
+    assert!(
+        rendered.iter().all(|line| !line.contains("│1│")),
+        "a valid oversized class diagram should not fall back to source"
+    );
+    assert!(
+        rendered.iter().any(|line| line.contains("BackendAdapter"))
+            && rendered.iter().any(|line| line.contains("+invoke"))
+            && rendered.iter().any(|line| line.contains("Client *--")),
+        "vertical class rendering should preserve classes, members, and relationships"
     );
 }
 


### PR DESCRIPTION
## What changed

- Make Mermaid rendering aware of the actual content width, including list and blockquote prefixes plus the surrounding frame.
- Keep the authored Mermaid layout when it fits.
- Retry oversized left-to-right flowcharts vertically before falling back.
- Retry oversized class diagrams horizontally when that produces a valid fit.
- Render class diagrams that still cannot fit as vertically stacked class cards followed by a compact relationship list.
- Fall back to syntax-highlighted Mermaid source when a valid two-dimensional render cannot fit safely, instead of wrapping rendered rows.
- Add `demo.md` with reproducible horizontal-flowchart and large-class-diagram examples.

## Why

Mermaid output is a pre-rendered two-dimensional text canvas. Leaf previously passed oversized diagram rows through the generic code-block wrapper. Wrapping those rows preserved the characters but broke their spatial relationships, splitting box borders, labels, and connectors across unrelated terminal rows.

A width guard prevents that corruption, but source fallback alone means large class diagrams no longer render at ordinary terminal widths. Class graphs with many wide cards and fan-out relationships can remain hundreds of columns wide in every graphical orientation.

This change treats Mermaid layout as responsive content. It tries alternate graph orientations when useful and uses a vertical class representation when no graphical orientation can fit. Class names, stereotypes, members, and authored relationships remain visible and searchable while the output grows downward instead of beyond the viewport.

## User impact

- Narrow terminals no longer show mangled Mermaid boxes and arrows.
- Wide terminals continue to receive the normal graphical rendering.
- Large class diagrams remain rendered and readable at common terminal widths rather than appearing as raw Mermaid source.
- Invalid or unsupported diagrams retain the existing source fallback.

## Validation

- `cargo fmt --all -- --check`
- `cargo test` — 416 passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`
- Manually rendered `demo.md` at 80 columns
- Manually rendered a 196 KB API design document containing the reported large class diagram at 80, 120, 240, and 320 columns
