### PR TITLE
fix: skip startup cursor query

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,8 @@
 use anyhow::{bail, Context, Result};
-use ratatui::{backend::CrosstermBackend, Terminal};
+use ratatui::{
+    backend::{Backend as _, ClearType, CrosstermBackend},
+    Terminal,
+};
 use std::{
     fs::OpenOptions,
     io::{self, IsTerminal, Read, Write},
@@ -535,7 +538,7 @@ fn main() -> Result<()> {
     runtime::debug_log(debug_input, "terminal enter done");
     let mut terminal = Terminal::new(CrosstermBackend::new(stdout))?;
     runtime::debug_log(debug_input, "terminal new done");
-    terminal.clear()?;
+    terminal.backend_mut().clear_region(ClearType::All)?;
     runtime::debug_log(debug_input, "terminal clear done");
     let initial_draw_result = (|| -> Result<()> {
         let area = terminal.size()?;


### PR DESCRIPTION
When ratatui 0.30's `terminal.clear()` was called right after entering alternate screen mode, the internal get_cursor_position() call sent a \`\x1b[6n\` (DSR) query that arrived before crossterm's event system was ready, causing a timeout and the raw response `^[[1;1R` to appear on screen. Replace it with `clear_region(ClearType::All)` on the backend directly, which skips the unnecessary cursor save/restore at this point in the startup sequence.